### PR TITLE
feat: Teams/Slack通知・サブステータス・フォーム改善を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,52 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { SettingsProvider } from './contexts/SettingsContext'
+import { SettingsProvider, useSettings } from './contexts/SettingsContext'
 import { CandidateProvider } from './contexts/CandidateContext'
 import { Sidebar } from './components/layout/Sidebar'
 import { CandidateListPage } from './pages/CandidateListPage'
 import { CandidateFormPage } from './pages/CandidateFormPage'
 import { CandidateDetailPage } from './pages/CandidateDetailPage'
 import { SettingsPage } from './pages/SettingsPage'
+import { SetupPage } from './pages/SetupPage'
+
+function AppRoutes() {
+  const { settings, isLoading } = useSettings()
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-sm text-gray-400">読み込み中...</p>
+      </div>
+    )
+  }
+
+  // 未初期化（初回起動）はセットアップ画面のみ表示
+  if (!settings?.initialized) {
+    return <SetupPage />
+  }
+
+  return (
+    <CandidateProvider>
+      <div className="flex h-screen overflow-hidden bg-gray-50">
+        <Sidebar />
+        <main className="flex-1 overflow-auto">
+          <Routes>
+            <Route path="/" element={<CandidateListPage />} />
+            <Route path="/candidates/new" element={<CandidateFormPage />} />
+            <Route path="/candidates/:id" element={<CandidateDetailPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </main>
+      </div>
+    </CandidateProvider>
+  )
+}
 
 export default function App() {
   return (
     <BrowserRouter>
       <SettingsProvider>
-        <CandidateProvider>
-          <div className="flex h-screen overflow-hidden bg-gray-50">
-            <Sidebar />
-            <main className="flex-1 overflow-auto">
-              <Routes>
-                <Route path="/" element={<CandidateListPage />} />
-                <Route path="/candidates/new" element={<CandidateFormPage />} />
-                <Route path="/candidates/:id" element={<CandidateDetailPage />} />
-                <Route path="/settings" element={<SettingsPage />} />
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Routes>
-            </main>
-          </div>
-        </CandidateProvider>
+        <AppRoutes />
       </SettingsProvider>
     </BrowserRouter>
   )

--- a/src/components/candidates/NotifyPanel.tsx
+++ b/src/components/candidates/NotifyPanel.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { useSettings } from '@/contexts/SettingsContext'
+import type { Candidate } from '@/types'
+import { templateKey, renderTemplate, DEFAULT_TEMPLATES } from '@/types'
+
+interface NotifyPanelProps {
+  candidate: Candidate
+  status: string // 変更後のステータス
+  deadline?: string | null
+  onSkip?: () => void
+  onPosted?: () => void
+}
+
+export function NotifyPanel({ candidate, status, deadline, onSkip, onPosted }: NotifyPanelProps) {
+  const { settings } = useSettings()
+  const webhookUrl = settings?.webhookUrl ?? ''
+  const webhookType = settings?.webhookType ?? null
+  const templates = settings?.messageTemplates ?? {}
+
+  const key = templateKey(candidate.type, status as any)
+  const baseTemplate = templates[key] ?? DEFAULT_TEMPLATES[key] ?? ''
+
+  const vars = {
+    名前: candidate.name,
+    媒体: candidate.source,
+    担当者: candidate.assignee || '未設定',
+    ステータス: status,
+    応募日: candidate.applicationDate ?? '—',
+    期限: deadline ?? candidate.deadline ?? '—',
+  }
+
+  const [message, setMessage] = useState(() => renderTemplate(baseTemplate, vars))
+  const [postStatus, setPostStatus] = useState<'idle' | 'sending' | 'ok' | 'error'>('idle')
+  const [errorMsg, setErrorMsg] = useState('')
+
+  const canPost = !!webhookUrl && !!webhookType
+
+  async function handlePost() {
+    if (!canPost) return
+    setPostStatus('sending')
+    setErrorMsg('')
+    try {
+      await window.electronAPI.postWebhook(webhookUrl, webhookType!, message)
+      setPostStatus('ok')
+      onPosted?.()
+    } catch (e: any) {
+      setPostStatus('error')
+      setErrorMsg(e?.message ?? '送信に失敗しました')
+    }
+  }
+
+  if (!baseTemplate) return null
+
+  return (
+    <div className="border border-blue-200 rounded-lg bg-blue-50 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-semibold text-blue-800">
+          {webhookType === 'teams' ? 'Teams' : webhookType === 'slack' ? 'Slack' : 'チャット'} に投稿
+        </h4>
+        {!canPost && (
+          <span className="text-xs text-gray-400">Webhook URLが未設定です</span>
+        )}
+      </div>
+
+      <textarea
+        value={message}
+        onChange={e => setMessage(e.target.value)}
+        rows={Math.max(3, message.split('\n').length + 1)}
+        disabled={!canPost}
+        className="w-full px-3 py-2 border border-blue-200 rounded-md text-sm font-mono bg-white resize-y focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-400"
+      />
+
+      <div className="flex items-center gap-3">
+        {canPost && (
+          <button
+            onClick={handlePost}
+            disabled={postStatus === 'sending' || postStatus === 'ok' || !message.trim()}
+            className="px-4 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium disabled:opacity-40 transition-colors"
+          >
+            {postStatus === 'sending' ? '送信中...' : postStatus === 'ok' ? '送信済み' : '投稿'}
+          </button>
+        )}
+        {onSkip && postStatus !== 'ok' && (
+          <button onClick={onSkip} className="text-xs text-gray-400 hover:text-gray-600">
+            スキップ
+          </button>
+        )}
+        {postStatus === 'ok' && (
+          <span className="text-xs text-green-600 font-medium">投稿しました</span>
+        )}
+        {postStatus === 'error' && (
+          <span className="text-xs text-red-500">{errorMsg}</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -20,6 +20,14 @@ interface TypeBadgeProps {
   type: 'graduate' | 'mid-career'
 }
 
+export function SubStatusBadge({ subStatus }: { subStatus: string }) {
+  return (
+    <span className="inline-flex items-center rounded-full text-xs px-2 py-0.5 font-medium bg-amber-50 text-amber-700 border border-amber-200">
+      {subStatus}
+    </span>
+  )
+}
+
 export function TypeBadge({ type }: TypeBadgeProps) {
   return (
     <span className={`inline-flex items-center rounded-full text-xs px-2 py-0.5 font-medium ${

--- a/src/contexts/CandidateContext.tsx
+++ b/src/contexts/CandidateContext.tsx
@@ -10,6 +10,7 @@ interface CandidateContextValue {
   addCandidate: (data: Omit<Candidate, 'id' | 'folderPath' | 'createdAt' | 'updatedAt' | 'stages' | 'files'>) => Promise<Candidate>
   updateCandidate: (id: string, updates: Partial<Candidate>) => Promise<void>
   changeStatus: (id: string, newStatus: CandidateStatus, stageRecord: Omit<StageRecord, 'stage'>) => Promise<void>
+  updateSubStatus: (id: string, subStatus: string | null) => Promise<void>
   deleteCandidate: (id: string) => Promise<void>
   addFile: (candidateId: string, srcPath: string, fileName: string, category: FileCategory) => Promise<void>
   removeFile: (candidateId: string, fileName: string) => Promise<void>
@@ -55,6 +56,7 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
       ...data,
       id,
       folderPath,
+      subStatus: data.subStatus ?? null,
       stages: [],
       files: [],
       createdAt: now,
@@ -86,12 +88,17 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
     const updated: Candidate = {
       ...candidate,
       status: newStatus,
+      subStatus: stageData.subStatus ?? null,  // ステータス変更時にサブステータスも更新
       folderPath: newFolderPath,
       stages: [...candidate.stages, stageRecord],
       updatedAt: now,
     }
     await saveCandidateProfile(updated)
     setCandidates(prev => prev.map(c => c.id === id ? updated : c))
+  }
+
+  async function updateSubStatus(id: string, subStatus: string | null) {
+    await updateCandidate(id, { subStatus })
   }
 
   async function deleteCandidate(id: string) {
@@ -121,7 +128,7 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
   return (
     <CandidateContext.Provider value={{
       candidates, isLoading, addCandidate, updateCandidate,
-      changeStatus, deleteCandidate, addFile, removeFile, reload
+      changeStatus, updateSubStatus, deleteCandidate, addFile, removeFile, reload
     }}>
       {children}
     </CandidateContext.Provider>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import type { AppSettings } from '@/types'
+import { DEFAULT_SUB_STATUSES } from '@/types'
 
 interface SettingsContextValue {
   settings: AppSettings | null
@@ -20,7 +21,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   async function loadSettings() {
     const settingsPath = await window.electronAPI.getSettingsPath()
     const data = await window.electronAPI.readJson<AppSettings>(settingsPath)
-    setSettings(data ?? { rootDir: '', initialized: false, assignees: [] })
+    setSettings(data ?? { rootDir: '', initialized: false, assignees: [], subStatuses: [...DEFAULT_SUB_STATUSES], webhookUrl: '', webhookType: null, messageTemplates: {} })
     setIsLoading(false)
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -117,3 +117,24 @@ ipcMain.handle('app:getSettingsPath', () => {
 ipcMain.handle('fs:exists', (_event, dirPath: string) => {
   return existsSync(dirPath)
 })
+
+// Webhook 送信（Teams / Slack）
+ipcMain.handle('webhook:post', async (_event, url: string, webhookType: 'teams' | 'slack', message: string) => {
+  let body: string
+  if (webhookType === 'teams') {
+    // Teams Incoming Webhook は {"text": "..."} で送信可能
+    body = JSON.stringify({ text: message })
+  } else {
+    // Slack Incoming Webhook
+    body = JSON.stringify({ text: message })
+  }
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  })
+  if (!response.ok) {
+    throw new Error(`Webhook 送信失敗: ${response.status} ${response.statusText}`)
+  }
+  return true
+})

--- a/src/pages/CandidateDetailPage.tsx
+++ b/src/pages/CandidateDetailPage.tsx
@@ -3,7 +3,9 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useCandidates } from '@/contexts/CandidateContext'
 import { useSettings } from '@/contexts/SettingsContext'
 import { StatusBadge, TypeBadge } from '@/components/common/Badge'
-import type { CandidateStatus, Rating, StageRecord, FileCategory } from '@/types'
+import { NotifyPanel } from '@/components/candidates/NotifyPanel'
+import { SubStatusBadge } from '@/components/common/Badge'
+import type { Candidate, CandidateStatus, Rating, StageRecord, FileCategory } from '@/types'
 import {
   GRADUATE_STATUSES, MID_CAREER_STATUSES, RATING_COLORS,
   FILE_CATEGORIES, detectFileCategory,
@@ -12,13 +14,17 @@ import {
 export function CandidateDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { candidates, changeStatus, addFile, removeFile, deleteCandidate, updateCandidate } = useCandidates()
+  const { candidates, changeStatus, updateSubStatus, addFile, removeFile, deleteCandidate, updateCandidate } = useCandidates()
   const { settings } = useSettings()
   const candidate = candidates.find(c => c.id === id)
   const registeredAssignees = settings?.assignees ?? []
+  const subStatusList = settings?.subStatuses ?? []
 
   const [showStatusModal, setShowStatusModal] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
+  const [notifyState, setNotifyState] = useState<{
+    status: CandidateStatus; deadline: string | null
+  } | null>(null)
 
   if (!candidate) {
     return <div className="p-8 text-gray-400">候補者が見つかりません</div>
@@ -32,7 +38,7 @@ export function CandidateDetailPage() {
     const files = Array.from(e.dataTransfer.files)
       .filter(f => /\.(pdf|xlsx|xls|docx|doc)$/i.test(f.name))
     for (const file of files) {
-      const path = (file as File & { path: string }).path
+      const path = window.electronAPI.getFilePath(file)
       const category: FileCategory = detectFileCategory(file.name) ?? 'その他'
       await addFile(candidate!.id, path, file.name, category)
     }
@@ -48,7 +54,7 @@ export function CandidateDetailPage() {
     <div className="flex flex-col h-full overflow-auto">
       {/* ヘッダー */}
       <div className="px-6 py-4 border-b border-gray-200 bg-white flex items-center justify-between">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 flex-wrap">
           <button onClick={() => navigate('/')} className="text-gray-400 hover:text-gray-600 text-sm">← 一覧</button>
           <h2 className="text-lg font-bold text-gray-800">{candidate.name}</h2>
           <TypeBadge type={candidate.type} />
@@ -56,6 +62,17 @@ export function CandidateDetailPage() {
             <span className="text-sm text-gray-400">{candidate.graduationYear}年卒</span>
           )}
           <StatusBadge status={candidate.status} />
+          {/* サブステータス */}
+          {candidate.subStatus && <SubStatusBadge subStatus={candidate.subStatus} />}
+          {/* サブステータス クイック変更 */}
+          <select
+            value={candidate.subStatus ?? ''}
+            onChange={e => updateSubStatus(candidate.id, e.target.value || null)}
+            className="text-xs px-2 py-1 border border-gray-200 rounded-md text-gray-500 bg-white hover:border-gray-300"
+          >
+            <option value="">サブステータスなし</option>
+            {subStatusList.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
         </div>
         <div className="flex gap-2">
           <button
@@ -95,11 +112,6 @@ export function CandidateDetailPage() {
               label="期限"
               value={candidate.deadline ? formatDate(candidate.deadline) : '—'}
               className={deadlineClass(candidate.deadline)}
-            />
-            <InfoRow
-              label="次アクション"
-              value={candidate.nextActionDate ? formatDate(candidate.nextActionDate) : '—'}
-              className={deadlineClass(candidate.nextActionDate)}
             />
           </InfoCard>
 
@@ -190,12 +202,33 @@ export function CandidateDetailPage() {
           candidate={candidate}
           statuses={statuses}
           registeredAssignees={registeredAssignees}
+          subStatusList={subStatusList}
           onClose={() => setShowStatusModal(false)}
           onSubmit={async (newStatus, record) => {
             await changeStatus(candidate.id, newStatus, record)
             setShowStatusModal(false)
+            setNotifyState({ status: newStatus, deadline: (record as any).deadline ?? null })
           }}
         />
+      )}
+
+      {/* ステータス変更後の投稿パネル */}
+      {notifyState && candidate && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl p-6 w-[520px] space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-bold text-gray-800">チャットに通知</h3>
+              <button onClick={() => setNotifyState(null)} className="text-gray-400 hover:text-gray-600 text-sm">✕</button>
+            </div>
+            <NotifyPanel
+              candidate={candidate}
+              status={notifyState.status}
+              deadline={notifyState.deadline}
+              onSkip={() => setNotifyState(null)}
+              onPosted={() => setTimeout(() => setNotifyState(null), 1200)}
+            />
+          </div>
+        </div>
       )}
     </div>
   )
@@ -225,10 +258,11 @@ function weekLater(from?: string): string {
   return d.toISOString().split('T')[0]
 }
 
-function StatusChangeModal({ candidate, statuses, registeredAssignees, onClose, onSubmit }: {
+function StatusChangeModal({ candidate, statuses, registeredAssignees, subStatusList, onClose, onSubmit }: {
   candidate: { status: CandidateStatus; type: string; assignee: string }
   statuses: CandidateStatus[]
   registeredAssignees: string[]
+  subStatusList: string[]
   onClose: () => void
   onSubmit: (status: CandidateStatus, record: Omit<StageRecord, 'stage'>) => Promise<void>
 }) {
@@ -236,6 +270,7 @@ function StatusChangeModal({ candidate, statuses, registeredAssignees, onClose, 
   const isMidCareer = candidate.type === 'mid-career'
 
   const [newStatus, setNewStatus] = useState<CandidateStatus>(candidate.status)
+  const [subStatus, setSubStatus] = useState('')
   const [date, setDate] = useState(today)
   const [evaluator, setEvaluator] = useState(candidate.assignee)
   const [deadline, setDeadline] = useState(isMidCareer ? weekLater() : '')
@@ -245,7 +280,11 @@ function StatusChangeModal({ candidate, statuses, registeredAssignees, onClose, 
 
   async function handleSubmit() {
     setIsLoading(true)
-    await onSubmit(newStatus, { date, evaluator, rating: rating || null, memo, deadline: deadline || null } as Omit<StageRecord, 'stage'>)
+    await onSubmit(newStatus, {
+      date, evaluator, rating: rating || null, memo,
+      subStatus: subStatus || null,
+      deadline: deadline || null,
+    } as Omit<StageRecord, 'stage'>)
     setIsLoading(false)
   }
 
@@ -254,15 +293,30 @@ function StatusChangeModal({ candidate, statuses, registeredAssignees, onClose, 
       <div className="bg-white rounded-xl shadow-xl p-6 w-[480px] space-y-4">
         <h3 className="text-base font-bold text-gray-800">ステータス変更</h3>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">新しいステータス</label>
-          <select
-            value={newStatus}
-            onChange={e => setNewStatus(e.target.value as CandidateStatus)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
-          >
-            {statuses.map(s => <option key={s} value={s}>{s}</option>)}
-          </select>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">新しいステータス</label>
+            <select
+              value={newStatus}
+              onChange={e => setNewStatus(e.target.value as CandidateStatus)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+            >
+              {statuses.map(s => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              サブステータス <span className="text-gray-400 font-normal text-xs">（任意）</span>
+            </label>
+            <select
+              value={subStatus}
+              onChange={e => setSubStatus(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+            >
+              <option value="">なし</option>
+              {subStatusList.map(s => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </div>
         </div>
 
         <div className="grid grid-cols-3 gap-3">

--- a/src/pages/CandidateFormPage.tsx
+++ b/src/pages/CandidateFormPage.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCandidates } from '@/contexts/CandidateContext'
 import { useSettings } from '@/contexts/SettingsContext'
-import type { RecruitmentType, CandidateStatus, RecruitmentSource, FileCategory } from '@/types'
+import { NotifyPanel } from '@/components/candidates/NotifyPanel'
+import type { Candidate, RecruitmentType, CandidateStatus, RecruitmentSource, FileCategory } from '@/types'
 import {
   GRADUATE_STATUSES, MID_CAREER_STATUSES,
   GRADUATE_SOURCES, MID_CAREER_SOURCES,
@@ -45,7 +46,6 @@ export function CandidateFormPage() {
   const [status, setStatus] = useState<CandidateStatus>('応募')
   const [applicationDate, setApplicationDate] = useState(today())
   const [deadline, setDeadline] = useState(() => type === 'mid-career' ? weekLater() : '')
-  const [nextActionDate, setNextActionDate] = useState('')
   const [assignee, setAssignee] = useState('')
   const [showRegisterAssignee, setShowRegisterAssignee] = useState(false)
   const [email, setEmail] = useState('')
@@ -54,6 +54,7 @@ export function CandidateFormPage() {
   const [droppedFiles, setDroppedFiles] = useState<DroppedFile[]>([])
   const [isDragging, setIsDragging] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [createdCandidate, setCreatedCandidate] = useState<Candidate | null>(null)
 
   const sources = type === 'graduate' ? GRADUATE_SOURCES : MID_CAREER_SOURCES
   const statuses = type === 'graduate' ? GRADUATE_STATUSES : MID_CAREER_STATUSES
@@ -97,7 +98,7 @@ export function CandidateFormPage() {
           .filter(f => !existing.has(f.name))
           .map(f => ({
             name: f.name,
-            path: (f as File & { path: string }).path,
+            path: window.electronAPI.getFilePath(f),
             category: detectFileCategory(f.name),
           }))
       ]
@@ -119,16 +120,51 @@ export function CandidateFormPage() {
         graduationYear: type === 'graduate' ? graduationYear : null,
         source, status, applicationDate,
         deadline: deadline || null,
-        nextActionDate: nextActionDate || null,
+        nextActionDate: null,
         assignee,
       })
       for (const f of droppedFiles) {
         await addFile(candidate.id, f.path, f.name, f.category!)
       }
-      navigate(`/candidates/${candidate.id}`)
+      setCreatedCandidate(candidate)
     } finally {
       setIsSubmitting(false)
     }
+  }
+
+  // 登録完了後：通知モーダル
+  if (createdCandidate) {
+    return (
+      <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+        <div className="bg-white rounded-xl shadow-xl p-6 w-[520px] space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-base font-bold text-gray-800">候補者を登録しました</h3>
+              <p className="text-xs text-gray-500 mt-0.5">{createdCandidate.name} — {createdCandidate.status}</p>
+            </div>
+            <button
+              onClick={() => navigate(`/candidates/${createdCandidate.id}`)}
+              className="text-gray-400 hover:text-gray-600 text-sm"
+            >
+              ✕
+            </button>
+          </div>
+          <NotifyPanel
+            candidate={createdCandidate}
+            status={createdCandidate.status}
+            deadline={createdCandidate.deadline}
+            onSkip={() => navigate(`/candidates/${createdCandidate.id}`)}
+            onPosted={() => setTimeout(() => navigate(`/candidates/${createdCandidate.id}`), 1200)}
+          />
+          <button
+            onClick={() => navigate(`/candidates/${createdCandidate.id}`)}
+            className="w-full py-2 border border-gray-200 rounded-md text-sm text-gray-500 hover:bg-gray-50"
+          >
+            詳細ページへ
+          </button>
+        </div>
+      </div>
+    )
   }
 
   return (
@@ -216,9 +252,14 @@ export function CandidateFormPage() {
               </FieldGroup>
             </div>
 
-            <FieldGroup label="応募日" required>
-              <Input type="date" value={applicationDate} onChange={e => setApplicationDate(e.target.value)} />
-            </FieldGroup>
+            <div className="grid grid-cols-2 gap-3">
+              <FieldGroup label="応募日" required>
+                <Input type="date" value={applicationDate} onChange={e => setApplicationDate(e.target.value)} />
+              </FieldGroup>
+              <FieldGroup label={type === 'mid-career' ? '期限（デフォルト1週間）' : '期限'}>
+                <Input type="date" value={deadline} onChange={e => setDeadline(e.target.value)} />
+              </FieldGroup>
+            </div>
 
             {/* 担当者（コンボボックス） */}
             <FieldGroup label="担当者">
@@ -243,14 +284,6 @@ export function CandidateFormPage() {
               )}
             </FieldGroup>
 
-            <div className="grid grid-cols-2 gap-3">
-              <FieldGroup label={type === 'mid-career' ? '期限（デフォルト1週間）' : '期限'}>
-                <Input type="date" value={deadline} onChange={e => setDeadline(e.target.value)} />
-              </FieldGroup>
-              <FieldGroup label="次アクション日">
-                <Input type="date" value={nextActionDate} onChange={e => setNextActionDate(e.target.value)} />
-              </FieldGroup>
-            </div>
           </div>
         </div>
 

--- a/src/pages/CandidateListPage.tsx
+++ b/src/pages/CandidateListPage.tsx
@@ -2,14 +2,14 @@ import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCandidates } from '@/contexts/CandidateContext'
 import { useSettings } from '@/contexts/SettingsContext'
-import { StatusBadge, TypeBadge } from '@/components/common/Badge'
+import { StatusBadge, SubStatusBadge, TypeBadge } from '@/components/common/Badge'
 import type { CandidateStatus, RecruitmentType, RecruitmentSource } from '@/types'
 import {
   GRADUATE_STATUSES, MID_CAREER_STATUSES,
   GRADUATE_SOURCES, MID_CAREER_SOURCES
 } from '@/types'
 
-type SortKey = 'name' | 'status' | 'deadline' | 'nextActionDate' | 'createdAt'
+type SortKey = 'name' | 'status' | 'deadline' | 'createdAt'
 type SortDir = 'asc' | 'desc'
 
 export function CandidateListPage() {
@@ -144,7 +144,6 @@ export function CandidateListPage() {
                 <Th onClick={() => toggleSort('status')} sortKey="status" currentSort={sortKey} dir={sortDir}>ステータス</Th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">担当者</th>
                 <Th onClick={() => toggleSort('deadline')} sortKey="deadline" currentSort={sortKey} dir={sortDir}>期限</Th>
-                <Th onClick={() => toggleSort('nextActionDate')} sortKey="nextActionDate" currentSort={sortKey} dir={sortDir}>次アクション</Th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100 bg-white">
@@ -162,13 +161,15 @@ export function CandidateListPage() {
                     )}
                   </td>
                   <td className="px-4 py-3 text-gray-600">{c.source}</td>
-                  <td className="px-4 py-3"><StatusBadge status={c.status} size="sm" /></td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      <StatusBadge status={c.status} size="sm" />
+                      {c.subStatus && <SubStatusBadge subStatus={c.subStatus} />}
+                    </div>
+                  </td>
                   <td className="px-4 py-3 text-gray-600">{c.assignee || '—'}</td>
                   <td className={`px-4 py-3 ${deadlineClass(c.deadline)}`}>
                     {c.deadline ? formatDate(c.deadline) : '—'}
-                  </td>
-                  <td className={`px-4 py-3 ${deadlineClass(c.nextActionDate)}`}>
-                    {c.nextActionDate ? formatDate(c.nextActionDate) : '—'}
                   </td>
                 </tr>
               ))}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,17 +1,67 @@
 import { useState } from 'react'
 import { useSettings } from '@/contexts/SettingsContext'
-import type { AppSettings } from '@/types'
+import type { AppSettings, CandidateStatus, RecruitmentType, WebhookType } from '@/types'
+import {
+  GRADUATE_STATUSES, MID_CAREER_STATUSES,
+  DEFAULT_TEMPLATES, templateKey, DEFAULT_SUB_STATUSES,
+} from '@/types'
+
+type Tab = 'general' | 'assignees' | 'sub-statuses' | 'webhook' | 'templates'
 
 export function SettingsPage() {
   const { settings, saveSettings } = useSettings()
-  const [rootDir, setRootDir] = useState(settings?.rootDir ?? '')
-  const [assignees, setAssignees] = useState<string[]>(settings?.assignees ?? [])
-  const [newAssignee, setNewAssignee] = useState('')
+  const [tab, setTab] = useState<Tab>('general')
   const [saved, setSaved] = useState(false)
 
-  async function handleSelectDir() {
-    const dir = await window.electronAPI.selectDirectory()
-    if (dir) setRootDir(dir)
+  // general
+  const [rootDir, setRootDir] = useState(settings?.rootDir ?? '')
+
+  // assignees
+  const [assignees, setAssignees] = useState<string[]>(settings?.assignees ?? [])
+  const [newAssignee, setNewAssignee] = useState('')
+
+  // sub-statuses
+  const [subStatuses, setSubStatuses] = useState<string[]>(
+    settings?.subStatuses ?? [...DEFAULT_SUB_STATUSES]
+  )
+  const [newSubStatus, setNewSubStatus] = useState('')
+
+  // webhook
+  const [webhookUrl, setWebhookUrl] = useState(settings?.webhookUrl ?? '')
+  const [webhookType, setWebhookType] = useState<WebhookType | null>(settings?.webhookType ?? null)
+  const [testStatus, setTestStatus] = useState<'idle' | 'sending' | 'ok' | 'error'>('idle')
+
+  // templates
+  const allStatuses = [...new Set([...GRADUATE_STATUSES, ...MID_CAREER_STATUSES])]
+  const savedTemplates = settings?.messageTemplates ?? {}
+  const [templates, setTemplates] = useState<Record<string, string>>(() => {
+    const merged: Record<string, string> = { ...DEFAULT_TEMPLATES }
+    for (const [k, v] of Object.entries(savedTemplates)) merged[k] = v
+    return merged
+  })
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+
+  function detectWebhookType(url: string): WebhookType | null {
+    if (url.includes('webhook.office.com') || url.includes('teams.microsoft.com')) return 'teams'
+    if (url.includes('hooks.slack.com')) return 'slack'
+    return null
+  }
+
+  function handleWebhookUrlChange(url: string) {
+    setWebhookUrl(url)
+    setWebhookType(detectWebhookType(url))
+    setTestStatus('idle')
+  }
+
+  async function handleTestWebhook() {
+    if (!webhookUrl || !webhookType) return
+    setTestStatus('sending')
+    try {
+      await window.electronAPI.postWebhook(webhookUrl, webhookType, '【テスト】採用管理ツールからの接続確認です。')
+      setTestStatus('ok')
+    } catch {
+      setTestStatus('error')
+    }
   }
 
   function addAssignee() {
@@ -25,103 +75,279 @@ export function SettingsPage() {
     setAssignees(prev => prev.filter(a => a !== name))
   }
 
+  function addSubStatus() {
+    const s = newSubStatus.trim()
+    if (!s || subStatuses.includes(s)) return
+    setSubStatuses(prev => [...prev, s])
+    setNewSubStatus('')
+  }
+
+  function removeSubStatus(s: string) {
+    setSubStatuses(prev => prev.filter(x => x !== s))
+  }
+
+  function updateTemplate(key: string, value: string) {
+    setTemplates(prev => ({ ...prev, [key]: value }))
+  }
+
+  function resetTemplate(key: string) {
+    setTemplates(prev => ({ ...prev, [key]: DEFAULT_TEMPLATES[key] ?? '' }))
+  }
+
+  async function handleSelectDir() {
+    const dir = await window.electronAPI.selectDirectory()
+    if (dir) setRootDir(dir)
+  }
+
   async function handleSave() {
     const newSettings: AppSettings = {
       rootDir,
       initialized: !!rootDir,
       assignees,
+      subStatuses,
+      webhookUrl,
+      webhookType: webhookType ?? detectWebhookType(webhookUrl),
+      messageTemplates: templates,
     }
     await saveSettings(newSettings)
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
   }
 
+  const TABS: { key: Tab; label: string }[] = [
+    { key: 'general', label: '基本' },
+    { key: 'assignees', label: '担当者' },
+    { key: 'sub-statuses', label: 'サブステータス' },
+    { key: 'webhook', label: '通知' },
+    { key: 'templates', label: 'テンプレート' },
+  ]
+
   return (
-    <div className="p-8 max-w-xl space-y-5">
-      <h2 className="text-xl font-bold text-gray-800">設定</h2>
+    <div className="p-8 max-w-2xl">
+      <h2 className="text-xl font-bold mb-5 text-gray-800">設定</h2>
 
-      {/* 採用管理フォルダ */}
-      <div className="bg-white rounded-lg border border-gray-200 p-5">
-        <h3 className="text-sm font-semibold text-gray-700 mb-3">採用管理フォルダ</h3>
-        <p className="text-xs text-gray-500 mb-3">
-          候補者のデータ・書類を保存するルートフォルダを指定してください。
-        </p>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={rootDir}
-            readOnly
-            placeholder="フォルダが選択されていません"
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 text-gray-700"
-          />
+      {/* タブ */}
+      <div className="flex border-b border-gray-200 mb-5">
+        {TABS.map(t => (
           <button
-            onClick={handleSelectDir}
-            className="px-4 py-2 bg-gray-100 hover:bg-gray-200 border border-gray-300 rounded-md text-sm font-medium transition-colors"
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              tab === t.key
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
           >
-            参照
+            {t.label}
           </button>
-        </div>
-        {rootDir && (
-          <button
-            onClick={() => window.electronAPI.openFolder(rootDir)}
-            className="mt-2 text-xs text-blue-600 hover:underline"
-          >
-            エクスプローラーで開く
-          </button>
-        )}
+        ))}
       </div>
 
-      {/* 担当者管理 */}
-      <div className="bg-white rounded-lg border border-gray-200 p-5">
-        <h3 className="text-sm font-semibold text-gray-700 mb-3">担当者</h3>
-        <p className="text-xs text-gray-500 mb-3">
-          候補者登録時に選択できる担当者を登録します。フォームで直接入力することも可能です。
-        </p>
-
-        <div className="flex gap-2 mb-3">
-          <input
-            type="text"
-            value={newAssignee}
-            onChange={e => setNewAssignee(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), addAssignee())}
-            placeholder="担当者名を入力"
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm"
-          />
-          <button
-            onClick={addAssignee}
-            disabled={!newAssignee.trim() || assignees.includes(newAssignee.trim())}
-            className="px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            追加
-          </button>
-        </div>
-
-        {assignees.length === 0 ? (
-          <p className="text-xs text-gray-400">担当者が登録されていません</p>
-        ) : (
-          <ul className="space-y-1">
-            {assignees.map(a => (
-              <li key={a} className="flex items-center justify-between px-3 py-1.5 bg-gray-50 border border-gray-100 rounded-md text-sm">
-                <span className="text-gray-700">{a}</span>
-                <button
-                  onClick={() => removeAssignee(a)}
-                  className="text-gray-400 hover:text-red-500 text-xs"
-                >
-                  削除
-                </button>
-              </li>
-            ))}
-          </ul>
+      <div className="space-y-4">
+        {/* 基本タブ */}
+        {tab === 'general' && (
+          <div className="bg-white rounded-lg border border-gray-200 p-5 space-y-3">
+            <h3 className="text-sm font-semibold text-gray-700">採用管理フォルダ</h3>
+            <p className="text-xs text-gray-500">候補者データ・書類を保存するルートフォルダ。</p>
+            <div className="flex gap-2">
+              <input
+                type="text" value={rootDir} readOnly
+                placeholder="フォルダが選択されていません"
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50"
+              />
+              <button onClick={handleSelectDir}
+                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 border border-gray-300 rounded-md text-sm font-medium">
+                参照
+              </button>
+            </div>
+            {rootDir && (
+              <button onClick={() => window.electronAPI.openFolder(rootDir)}
+                className="text-xs text-blue-600 hover:underline">
+                エクスプローラーで開く
+              </button>
+            )}
+          </div>
         )}
-      </div>
 
-      <button
-        onClick={handleSave}
-        disabled={!rootDir}
-        className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-      >
-        {saved ? '保存しました' : '保存'}
-      </button>
+        {/* 担当者タブ */}
+        {tab === 'assignees' && (
+          <div className="bg-white rounded-lg border border-gray-200 p-5">
+            <h3 className="text-sm font-semibold text-gray-700 mb-1">担当者リスト</h3>
+            <p className="text-xs text-gray-500 mb-3">候補者登録時に選択できる担当者を登録します。</p>
+            <div className="flex gap-2 mb-3">
+              <input
+                type="text" value={newAssignee}
+                onChange={e => setNewAssignee(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), addAssignee())}
+                placeholder="担当者名"
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm"
+              />
+              <button onClick={addAssignee}
+                disabled={!newAssignee.trim() || assignees.includes(newAssignee.trim())}
+                className="px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium disabled:opacity-40">
+                追加
+              </button>
+            </div>
+            {assignees.length === 0
+              ? <p className="text-xs text-gray-400">担当者が登録されていません</p>
+              : (
+                <ul className="space-y-1">
+                  {assignees.map(a => (
+                    <li key={a} className="flex items-center justify-between px-3 py-1.5 bg-gray-50 border border-gray-100 rounded-md text-sm">
+                      <span>{a}</span>
+                      <button onClick={() => removeAssignee(a)} className="text-gray-400 hover:text-red-500 text-xs">削除</button>
+                    </li>
+                  ))}
+                </ul>
+              )
+            }
+          </div>
+        )}
+
+        {/* サブステータスタブ */}
+        {tab === 'sub-statuses' && (
+          <div className="bg-white rounded-lg border border-gray-200 p-5">
+            <h3 className="text-sm font-semibold text-gray-700 mb-1">サブステータスリスト</h3>
+            <p className="text-xs text-gray-500 mb-3">
+              全ステータス共通で使えるサブステータスを管理します。順番はドラッグで変更できます。
+            </p>
+            <div className="flex gap-2 mb-3">
+              <input
+                type="text" value={newSubStatus}
+                onChange={e => setNewSubStatus(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), addSubStatus())}
+                placeholder="サブステータス名"
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm"
+              />
+              <button onClick={addSubStatus}
+                disabled={!newSubStatus.trim() || subStatuses.includes(newSubStatus.trim())}
+                className="px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium disabled:opacity-40">
+                追加
+              </button>
+            </div>
+            {subStatuses.length === 0
+              ? <p className="text-xs text-gray-400">サブステータスが登録されていません</p>
+              : (
+                <ul className="space-y-1">
+                  {subStatuses.map(s => (
+                    <li key={s} className="flex items-center justify-between px-3 py-1.5 bg-amber-50 border border-amber-100 rounded-md text-sm">
+                      <span className="text-amber-800">{s}</span>
+                      <button onClick={() => removeSubStatus(s)} className="text-gray-400 hover:text-red-500 text-xs">削除</button>
+                    </li>
+                  ))}
+                </ul>
+              )
+            }
+          </div>
+        )}
+
+        {/* 通知タブ */}
+        {tab === 'webhook' && (
+          <div className="bg-white rounded-lg border border-gray-200 p-5 space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 mb-1">Incoming Webhook URL</h3>
+              <p className="text-xs text-gray-500 mb-2">
+                Teams または Slack の Incoming Webhook URL を入力してください。URLから自動判別します。
+              </p>
+              <input
+                type="url" value={webhookUrl}
+                onChange={e => handleWebhookUrlChange(e.target.value)}
+                placeholder="https://..."
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              />
+              {webhookUrl && (
+                <p className="mt-1 text-xs text-gray-500">
+                  種別: <span className="font-medium text-gray-700">{webhookType ?? '不明（TeamsまたはSlackのURLを入力してください）'}</span>
+                </p>
+              )}
+            </div>
+
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleTestWebhook}
+                disabled={!webhookUrl || !webhookType || testStatus === 'sending'}
+                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 border border-gray-300 rounded-md text-sm font-medium disabled:opacity-40"
+              >
+                {testStatus === 'sending' ? '送信中...' : '接続テスト'}
+              </button>
+              {testStatus === 'ok' && <span className="text-xs text-green-600 font-medium">送信成功</span>}
+              {testStatus === 'error' && <span className="text-xs text-red-500 font-medium">送信失敗。URLを確認してください</span>}
+            </div>
+          </div>
+        )}
+
+        {/* テンプレートタブ */}
+        {tab === 'templates' && (
+          <div className="space-y-3">
+            <p className="text-xs text-gray-500">
+              使用できる変数: <code className="bg-gray-100 px-1 rounded">{'{{名前}}'}</code>
+              <code className="bg-gray-100 px-1 rounded ml-1">{'{{媒体}}'}</code>
+              <code className="bg-gray-100 px-1 rounded ml-1">{'{{担当者}}'}</code>
+              <code className="bg-gray-100 px-1 rounded ml-1">{'{{ステータス}}'}</code>
+              <code className="bg-gray-100 px-1 rounded ml-1">{'{{応募日}}'}</code>
+              <code className="bg-gray-100 px-1 rounded ml-1">{'{{期限}}'}</code>
+            </p>
+
+            {(['graduate', 'mid-career'] as RecruitmentType[]).map(type => {
+              const statuses = type === 'graduate' ? GRADUATE_STATUSES : MID_CAREER_STATUSES
+              return (
+                <div key={type} className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="px-4 py-2.5 bg-gray-50 border-b border-gray-100">
+                    <span className="text-sm font-semibold text-gray-700">
+                      {type === 'graduate' ? '新卒' : '中途'}
+                    </span>
+                  </div>
+                  <div className="divide-y divide-gray-100">
+                    {statuses.map(status => {
+                      const key = templateKey(type, status)
+                      const isEditing = editingKey === key
+                      return (
+                        <div key={key} className="px-4 py-3">
+                          <div className="flex items-center justify-between mb-1.5">
+                            <span className="text-xs font-medium text-gray-600">{status}</span>
+                            <div className="flex gap-2">
+                              {isEditing && (
+                                <button onClick={() => resetTemplate(key)}
+                                  className="text-xs text-gray-400 hover:text-gray-600">デフォルトに戻す</button>
+                              )}
+                              <button
+                                onClick={() => setEditingKey(isEditing ? null : key)}
+                                className="text-xs text-blue-600 hover:underline"
+                              >
+                                {isEditing ? '折り畳む' : '編集'}
+                              </button>
+                            </div>
+                          </div>
+                          {isEditing ? (
+                            <textarea
+                              value={templates[key] ?? ''}
+                              onChange={e => updateTemplate(key, e.target.value)}
+                              rows={4}
+                              className="w-full px-3 py-2 border border-gray-300 rounded-md text-xs font-mono resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            />
+                          ) : (
+                            <p className="text-xs text-gray-500 whitespace-pre-wrap line-clamp-2">
+                              {templates[key] ?? DEFAULT_TEMPLATES[key] ?? '（テンプレートなし）'}
+                            </p>
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        <button
+          onClick={handleSave}
+          disabled={!rootDir}
+          className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium transition-colors disabled:opacity-40"
+        >
+          {saved ? '保存しました' : '保存'}
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { useSettings } from '@/contexts/SettingsContext'
+import type { AppSettings } from '@/types'
+import { DEFAULT_SUB_STATUSES } from '@/types'
+
+export function SetupPage() {
+  const { saveSettings } = useSettings()
+  const [rootDir, setRootDir] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+
+  async function handleSelectDir() {
+    const dir = await window.electronAPI.selectDirectory()
+    if (dir) setRootDir(dir)
+  }
+
+  async function handleStart() {
+    if (!rootDir) return
+    setIsSaving(true)
+    const settings: AppSettings = {
+      rootDir,
+      initialized: true,
+      assignees: [],
+      subStatuses: [...DEFAULT_SUB_STATUSES],
+      webhookUrl: '',
+      webhookType: null,
+      messageTemplates: {},
+    }
+    await saveSettings(settings)
+    setIsSaving(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-10 w-full max-w-md space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">採用管理</h1>
+          <p className="mt-2 text-sm text-gray-500">
+            はじめに、候補者データと書類を保存するフォルダを指定してください。
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">
+            採用管理フォルダ <span className="text-red-500">*</span>
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={rootDir}
+              readOnly
+              placeholder="フォルダを選択してください"
+              className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 text-gray-700"
+            />
+            <button
+              onClick={handleSelectDir}
+              className="px-4 py-2 bg-gray-100 hover:bg-gray-200 border border-gray-300 rounded-md text-sm font-medium transition-colors"
+            >
+              参照
+            </button>
+          </div>
+          {rootDir && (
+            <p className="text-xs text-gray-400 break-all">{rootDir}</p>
+          )}
+        </div>
+
+        <button
+          onClick={handleStart}
+          disabled={!rootDir || isSaving}
+          className="w-full py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {isSaving ? '設定中...' : '開始する'}
+        </button>
+
+        <p className="text-xs text-gray-400 text-center">
+          設定はあとから「設定」画面で変更できます。
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // ダイアログ
@@ -20,4 +20,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // アプリ設定
   getSettingsPath: () => ipcRenderer.invoke('app:getSettingsPath'),
+
+  // Webhook
+  postWebhook: (url: string, type: 'teams' | 'slack', message: string) =>
+    ipcRenderer.invoke('webhook:post', url, type, message) as Promise<true>,
+
+  // ファイルパス取得（Electron 28+ サンドボックス対応）
+  getFilePath: (file: File) => webUtils.getPathForFile(file),
 })

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -11,6 +11,8 @@ export interface ElectronAPI {
   writeJson: (filePath: string, data: unknown) => Promise<boolean>
   exists: (path: string) => Promise<boolean>
   getSettingsPath: () => Promise<string>
+  postWebhook: (url: string, type: 'teams' | 'slack', message: string) => Promise<true>
+  getFilePath: (file: File) => string
 }
 
 declare global {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,13 +27,21 @@ export type CandidateStatus = GraduateStatus | MidCareerStatus
 
 export type Rating = 'S' | 'A' | 'B' | 'C' | 'D'
 
+export const DEFAULT_SUB_STATUSES = [
+  '日程調整中',
+  '次回選考の意思確認中',
+  '結果待ち（社内検討中）',
+  'オファー条件交渉中',
+] as const
+
 export interface StageRecord {
   stage: CandidateStatus
   date: string
   evaluator: string
   rating: Rating | null
   memo: string
-  deadline?: string | null  // 中途：ステータス変更時の次回期限
+  subStatus?: string | null  // サブステータス
+  deadline?: string | null   // 中途：ステータス変更時の次回期限
 }
 
 export type FileCategory = '履歴書' | '職務経歴書' | '成績証明書' | '卒業見込み' | 'その他'
@@ -74,9 +82,9 @@ export interface Candidate {
   graduationYear: string | null  // 新卒のみ（例: "2026"）
   source: RecruitmentSource
   status: CandidateStatus
+  subStatus: string | null       // サブステータス（例: 日程調整中）
   applicationDate: string        // 応募日
   deadline: string | null        // 期限
-  nextActionDate: string | null  // 次アクション日
   assignee: string               // 担当者
   stages: StageRecord[]
   files: CandidateFile[]
@@ -85,10 +93,72 @@ export interface Candidate {
   updatedAt: string
 }
 
+export type WebhookType = 'teams' | 'slack'
+
 export interface AppSettings {
   rootDir: string
   initialized: boolean
-  assignees: string[]  // 登録済み担当者リスト
+  assignees: string[]
+  subStatuses: string[]          // カスタムサブステータスリスト
+  webhookUrl: string           // Teams または Slack の Incoming Webhook URL
+  webhookType: WebhookType | null
+  messageTemplates: Record<string, string>  // key: `${type}_${status}`
+}
+
+// テンプレート変数: {{名前}} {{媒体}} {{担当者}} {{ステータス}} {{応募日}} {{期限}}
+export type TemplateVars = {
+  名前: string
+  媒体: string
+  担当者: string
+  ステータス: string
+  応募日: string
+  期限: string
+}
+
+export function renderTemplate(template: string, vars: TemplateVars): string {
+  return template.replace(/\{\{(.+?)\}\}/g, (_, key) => {
+    return (vars as Record<string, string>)[key.trim()] ?? `{{${key}}}`
+  })
+}
+
+/** type と status から template キーを生成 */
+export function templateKey(type: RecruitmentType, status: CandidateStatus): string {
+  return `${type}_${status}`
+}
+
+export const DEFAULT_TEMPLATES: Record<string, string> = {
+  // 新卒
+  'graduate_応募':
+    '【新卒応募】{{名前}}さん（{{媒体}}）が応募しました。\n担当: {{担当者}}\n応募日: {{応募日}}',
+  'graduate_書類選考':
+    '【書類選考】{{名前}}さんを書類選考中です。\n担当: {{担当者}}\n期限: {{期限}}',
+  'graduate_一次面接':
+    '【一次面接依頼】{{名前}}さんの書類選考が通過しました。\n一次面接の日程調整をお願いします。\n担当: {{担当者}}\n期限: {{期限}}',
+  'graduate_最終面接':
+    '【最終面接依頼】{{名前}}さんが一次面接を通過しました。\n最終面接の日程調整をお願いします。\n担当: {{担当者}}\n期限: {{期限}}',
+  'graduate_内定':
+    '【内定】{{名前}}さんに内定を出しました。\n担当: {{担当者}}',
+  'graduate_不採用':
+    '【不採用】{{名前}}さんの選考を終了しました。\n担当: {{担当者}}',
+  'graduate_辞退':
+    '【辞退】{{名前}}さんが辞退されました。\n担当: {{担当者}}',
+  // 中途
+  'mid-career_応募':
+    '【中途応募】{{名前}}さん（{{媒体}}）が応募しました。\n担当: {{担当者}}\n応募日: {{応募日}}\n期限: {{期限}}',
+  'mid-career_カジュアル面談':
+    '【カジュアル面談】{{名前}}さんのカジュアル面談を設定してください。\n担当: {{担当者}}\n期限: {{期限}}',
+  'mid-career_書類選考':
+    '【書類選考】{{名前}}さんを書類選考中です。\n担当: {{担当者}}\n期限: {{期限}}',
+  'mid-career_一次面接':
+    '【一次面接依頼】{{名前}}さんの書類選考が通過しました。\n一次面接の日程調整をお願いします。\n担当: {{担当者}}\n期限: {{期限}}',
+  'mid-career_最終面接':
+    '【最終面接依頼】{{名前}}さんが一次面接を通過しました。\n最終面接の日程調整をお願いします。\n担当: {{担当者}}\n期限: {{期限}}',
+  'mid-career_内定':
+    '【内定】{{名前}}さんに内定を出しました。\n担当: {{担当者}}',
+  'mid-career_不採用':
+    '【不採用】{{名前}}さんの選考を終了しました。\n担当: {{担当者}}',
+  'mid-career_辞退':
+    '【辞退】{{名前}}さんが辞退されました。\n担当: {{担当者}}',
 }
 
 // 定数


### PR DESCRIPTION
## 概要

Teams/Slack通知機能、サブステータス機能、フォームUIの改善をまとめて追加します。

## 変更内容

### Teams/Slack 通知投稿
- ステータス変更時・候補者登録時に定型文をその場で編集・投稿できる `NotifyPanel` を追加
- Incoming Webhook URL から Teams/Slack を自動判別
- 設定画面から接続テストが可能

### サブステータス
- 全ステータス共通のサブステータス（日程調整中・意思確認中・結果待ち・オファー条件交渉中）を追加
- 一覧・詳細画面でバッジ表示
- ステータス変更モーダルから設定・解除可能

### テンプレート管理
- 通知文テンプレートをステータス×採用区分（新卒/中途）ごとに設定可能
- 変数（`{{名前}}` `{{媒体}}` `{{担当者}}` 等）による動的置換

### 設定画面リニューアル
- タブ型UI（基本 / 担当者 / サブステータス / 通知 / テンプレート）に刷新

### フォーム改善
- 応募日と期限日を横並び配置
- 次アクション日フィールドを削除

## テスト結果

- ビルド: 成功（main/preload/renderer 全て）
- 型エラー: なし