### PR TITLE
fix: Issue連続改修 (#2〜#116)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -2,24 +2,35 @@ import { resolve } from 'path'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  main: {
-    plugins: [externalizeDepsPlugin()]
-  },
-  preload: {
-    plugins: [externalizeDepsPlugin()]
-  },
-  renderer: {
-    resolve: {
-      alias: {
-        '@': resolve('src')
-      }
+export default defineConfig(({ mode }) => {
+  const isDev = mode === 'development'
+
+  return {
+    main: {
+      plugins: [externalizeDepsPlugin()],
+      build: {
+        sourcemap: isDev ? 'inline' : false,
+      },
     },
-    plugins: [react()],
-    root: resolve('.'),
-    build: {
-      rollupOptions: {
-        input: resolve('index.html')
+    preload: {
+      plugins: [externalizeDepsPlugin()],
+      build: {
+        sourcemap: isDev ? 'inline' : false,
+      },
+    },
+    renderer: {
+      resolve: {
+        alias: {
+          '@': resolve('src')
+        }
+      },
+      plugins: [react()],
+      root: resolve('.'),
+      build: {
+        sourcemap: isDev ? 'inline' : false,
+        rollupOptions: {
+          input: resolve('index.html')
+        }
       }
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { Component, useEffect, useRef, useState } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+import { HashRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { SettingsProvider, useSettings } from './contexts/SettingsContext'
 import { CandidateProvider } from './contexts/CandidateContext'
 import { Sidebar } from './components/layout/Sidebar'
@@ -8,10 +10,64 @@ import { CandidateDetailPage } from './pages/CandidateDetailPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { SetupPage } from './pages/SetupPage'
 
+class ErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean; message: string }
+> {
+  constructor(props: { children: ReactNode }) {
+    super(props)
+    this.state = { hasError: false, message: '' }
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    return {
+      hasError: true,
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+
+  componentDidCatch(_error: unknown, _info: ErrorInfo) {
+    // エラーは getDerivedStateFromError で捕捉済み
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+          <div className="bg-white rounded-2xl shadow-sm border border-red-200 p-8 max-w-md w-full space-y-4 text-center">
+            <p className="text-sm font-medium text-red-600">予期しないエラーが発生しました</p>
+            <p className="text-xs text-gray-500 break-all">{this.state.message}</p>
+            <button
+              onClick={() => window.location.reload()}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors"
+            >
+              再読み込み
+            </button>
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
 function AppRoutes() {
   const { settings, isLoading } = useSettings()
+  const prevInitialized = useRef<boolean | undefined>(undefined)
+  const [isTransitioning, setIsTransitioning] = useState(false)
 
-  if (isLoading) {
+  useEffect(() => {
+    // SetupPage 完了直後（initialized が false→true に変わった瞬間）に
+    // CandidateProvider のマウントが完了するまで 1 フレーム待つ
+    if (prevInitialized.current === false && settings?.initialized === true) {
+      setIsTransitioning(true)
+      const id = requestAnimationFrame(() => setIsTransitioning(false))
+      return () => cancelAnimationFrame(id)
+    }
+    prevInitialized.current = settings?.initialized
+  }, [settings?.initialized])
+
+  if (isLoading || isTransitioning) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <p className="text-sm text-gray-400">読み込み中...</p>
@@ -43,11 +99,40 @@ function AppRoutes() {
 }
 
 export default function App() {
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+
+    const apply = (dark: boolean) => {
+      document.documentElement.classList.toggle('dark', dark)
+    }
+
+    apply(mq.matches)
+    mq.addEventListener('change', e => apply(e.matches))
+
+    return () => {
+      mq.removeEventListener('change', e => apply(e.matches))
+    }
+  }, [])
+
+  // Electron 環境外（ブラウザ直接アクセス等）での明示的なエラー表示
+  if (!window.electronAPI) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 max-w-md w-full text-center space-y-2">
+          <p className="text-sm font-medium text-gray-700">このアプリは Electron 環境でのみ動作します</p>
+          <p className="text-xs text-gray-400">デスクトップアプリとして起動してください</p>
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <BrowserRouter>
-      <SettingsProvider>
-        <AppRoutes />
-      </SettingsProvider>
-    </BrowserRouter>
+    <HashRouter>
+      <ErrorBoundary>
+        <SettingsProvider>
+          <AppRoutes />
+        </SettingsProvider>
+      </ErrorBoundary>
+    </HashRouter>
   )
 }

--- a/src/components/candidates/NotifyPanel.tsx
+++ b/src/components/candidates/NotifyPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSettings } from '@/contexts/SettingsContext'
 import type { Candidate } from '@/types'
 import { templateKey, renderTemplate, DEFAULT_TEMPLATES } from '@/types'
@@ -31,9 +31,13 @@ export function NotifyPanel({ candidate, status, deadline, onSkip, onPosted }: N
 
   const [message, setMessage] = useState(() => renderTemplate(baseTemplate, vars))
   const [postStatus, setPostStatus] = useState<'idle' | 'sending' | 'ok' | 'error'>('idle')
+
+  useEffect(() => {
+    setMessage(renderTemplate(baseTemplate, vars))
+  }, [candidate, status])
   const [errorMsg, setErrorMsg] = useState('')
 
-  const canPost = !!webhookUrl && !!webhookType
+  const canPost = !!webhookUrl && !!webhookType && !!window.electronAPI?.postWebhook
 
   async function handlePost() {
     if (!canPost) return

--- a/src/components/candidates/NotifyPanel.tsx
+++ b/src/components/candidates/NotifyPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useSettings } from '@/contexts/SettingsContext'
 import type { Candidate } from '@/types'
 import { templateKey, renderTemplate, DEFAULT_TEMPLATES } from '@/types'
@@ -39,17 +39,32 @@ export function NotifyPanel({ candidate, status, deadline, onSkip, onPosted }: N
 
   const canPost = !!webhookUrl && !!webhookType && !!window.electronAPI?.postWebhook
 
+  const WEBHOOK_LABEL: Record<string, string> = { teams: 'Teams', slack: 'Slack' }
+  const webhookLabel = (webhookType && WEBHOOK_LABEL[webhookType]) ?? 'チャット'
+
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
   async function handlePost() {
     if (!canPost) return
     setPostStatus('sending')
     setErrorMsg('')
     try {
       await window.electronAPI.postWebhook(webhookUrl, webhookType!, message)
-      setPostStatus('ok')
-      onPosted?.()
+      if (mountedRef.current) {
+        setPostStatus('ok')
+        onPosted?.()
+      }
     } catch (e: any) {
-      setPostStatus('error')
-      setErrorMsg(e?.message ?? '送信に失敗しました')
+      if (mountedRef.current) {
+        setPostStatus('error')
+        setErrorMsg(e?.message ?? '送信に失敗しました')
+      }
     }
   }
 
@@ -59,7 +74,7 @@ export function NotifyPanel({ candidate, status, deadline, onSkip, onPosted }: N
     <div className="border border-blue-200 rounded-lg bg-blue-50 p-4 space-y-3">
       <div className="flex items-center justify-between">
         <h4 className="text-sm font-semibold text-blue-800">
-          {webhookType === 'teams' ? 'Teams' : webhookType === 'slack' ? 'Slack' : 'チャット'} に投稿
+          {webhookLabel} に投稿
         </h4>
         {!canPost && (
           <span className="text-xs text-gray-400">Webhook URLが未設定です</span>

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export function StatusBadge({ status, size = 'md' }: Props) {
-  const color = STATUS_COLORS[status] ?? 'bg-gray-100 text-gray-700'
+  const color = STATUS_COLORS[status]
   const sizeClass = size === 'sm' ? 'text-xs px-1.5 py-0.5' : 'text-xs px-2.5 py-1'
   return (
     <span className={`inline-flex items-center rounded-full font-medium ${color} ${sizeClass}`}>

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -21,6 +21,7 @@ interface TypeBadgeProps {
 }
 
 export function SubStatusBadge({ subStatus }: { subStatus: string }) {
+  if (!subStatus) return null
   return (
     <span className="inline-flex items-center rounded-full text-xs px-2 py-0.5 font-medium bg-amber-50 text-amber-700 border border-amber-200">
       {subStatus}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,12 @@
 import { NavLink } from 'react-router-dom'
 
-const navItems = [
+interface NavItem {
+  to: string
+  label: string
+  icon: string
+}
+
+const navItems: NavItem[] = [
   { to: '/', label: '候補者一覧', icon: '👥' },
   { to: '/candidates/new', label: '候補者追加', icon: '➕' },
   { to: '/settings', label: '設定', icon: '⚙️' },

--- a/src/contexts/CandidateContext.tsx
+++ b/src/contexts/CandidateContext.tsx
@@ -27,9 +27,12 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
   const reload = useCallback(async () => {
     if (!settings?.initialized || !settings.rootDir) return
     setIsLoading(true)
-    const loaded = await scanCandidates(settings.rootDir)
-    setCandidates(loaded)
-    setIsLoading(false)
+    try {
+      const loaded = await scanCandidates(settings.rootDir)
+      setCandidates(loaded)
+    } finally {
+      setIsLoading(false)
+    }
   }, [settings])
 
   useEffect(() => {
@@ -42,6 +45,7 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
   }
 
   async function addCandidate(data: Omit<Candidate, 'id' | 'folderPath' | 'createdAt' | 'updatedAt' | 'stages' | 'files'>): Promise<Candidate> {
+    if (!settings?.initialized || !settings.rootDir) throw new Error('設定が初期化されていません')
     const id = uuidv4()
     const now = new Date().toISOString()
     const folderPath = buildCandidateFolderPath(
@@ -70,21 +74,25 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
 
   async function updateCandidate(id: string, updates: Partial<Candidate>) {
     const now = new Date().toISOString()
-    setCandidates(prev => {
-      const next = prev.map(c => c.id === id ? { ...c, ...updates, updatedAt: now } : c)
-      const updated = next.find(c => c.id === id)
-      if (updated) saveCandidateProfile(updated)
-      return next
-    })
+    setCandidates(prev => prev.map(c => c.id === id ? { ...c, ...updates, updatedAt: now } : c))
+    const updated = candidates.find(c => c.id === id)
+    if (updated) await saveCandidateProfile({ ...updated, ...updates, updatedAt: now })
   }
 
   async function changeStatus(id: string, newStatus: CandidateStatus, stageData: Omit<StageRecord, 'stage'>) {
     const candidate = candidates.find(c => c.id === id)
     if (!candidate) return
 
-    const newFolderPath = await moveCandidateFolder(candidate, settings!.rootDir, newStatus)
     const stageRecord: StageRecord = { ...stageData, stage: newStatus }
     const now = new Date().toISOString()
+    const newFolderPath = buildCandidateFolderPath(
+      settings!.rootDir,
+      candidate.type,
+      newStatus,
+      candidate.name,
+      candidate.id,
+      candidate.graduationYear
+    )
     const updated: Candidate = {
       ...candidate,
       status: newStatus,
@@ -93,15 +101,20 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
       stages: [...candidate.stages, stageRecord],
       updatedAt: now,
     }
+    // saveProfile が失敗した場合はエラーをスローしてフォルダ移動を中止する
     await saveCandidateProfile(updated)
+    await moveCandidateFolder(candidate, settings!.rootDir, newStatus)
     setCandidates(prev => prev.map(c => c.id === id ? updated : c))
   }
+
 
   async function updateSubStatus(id: string, subStatus: string | null) {
     await updateCandidate(id, { subStatus })
   }
 
   async function deleteCandidate(id: string) {
+    const candidate = candidates.find(c => c.id === id)
+    if (candidate) await window.electronAPI.deleteDir(candidate.folderPath)
     setCandidates(prev => prev.filter(c => c.id !== id))
   }
 

--- a/src/contexts/CandidateContext.tsx
+++ b/src/contexts/CandidateContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import type { Candidate, CandidateStatus, StageRecord, FileCategory } from '@/types'
-import { buildCandidateFolderPath, moveCandidateFolder, getProfileJsonPath } from '@/utils/folderStructure'
+import { buildCandidateFolderPath, moveCandidateFolder, getProfileJsonPath, TYPE_FOLDER_MAP } from '@/utils/folderStructure'
 import { useSettings } from './SettingsContext'
 
 interface CandidateContextValue {
@@ -74,9 +74,11 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
 
   async function updateCandidate(id: string, updates: Partial<Candidate>) {
     const now = new Date().toISOString()
-    setCandidates(prev => prev.map(c => c.id === id ? { ...c, ...updates, updatedAt: now } : c))
-    const updated = candidates.find(c => c.id === id)
-    if (updated) await saveCandidateProfile({ ...updated, ...updates, updatedAt: now })
+    const target = candidates.find(c => c.id === id)
+    if (!target) return
+    const updated = { ...target, ...updates, updatedAt: now }
+    setCandidates(prev => prev.map(c => c.id === id ? updated : c))
+    await saveCandidateProfile(updated)
   }
 
   async function changeStatus(id: string, newStatus: CandidateStatus, stageData: Omit<StageRecord, 'stage'>) {
@@ -85,8 +87,9 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
 
     const stageRecord: StageRecord = { ...stageData, stage: newStatus }
     const now = new Date().toISOString()
+    if (!settings?.rootDir) throw new Error('設定が初期化されていません')
     const newFolderPath = buildCandidateFolderPath(
-      settings!.rootDir,
+      settings.rootDir,
       candidate.type,
       newStatus,
       candidate.name,
@@ -103,7 +106,7 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
     }
     // saveProfile が失敗した場合はエラーをスローしてフォルダ移動を中止する
     await saveCandidateProfile(updated)
-    await moveCandidateFolder(candidate, settings!.rootDir, newStatus)
+    await moveCandidateFolder(candidate, settings.rootDir, newStatus)
     setCandidates(prev => prev.map(c => c.id === id ? updated : c))
   }
 
@@ -122,7 +125,8 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
     const candidate = candidates.find(c => c.id === candidateId)
     if (!candidate) return
     const destPath = `${candidate.folderPath}/${fileName}`
-    await window.electronAPI.copyFile(srcPath, destPath)
+    const copied = await window.electronAPI.copyFile(srcPath, destPath)
+    if (!copied) throw new Error(`ファイルのコピーに失敗しました: ${fileName}`)
     await updateCandidate(candidateId, {
       files: [...candidate.files, { name: fileName, path: destPath, category }]
     })
@@ -132,6 +136,7 @@ export function CandidateProvider({ children }: { children: ReactNode }) {
     const candidate = candidates.find(c => c.id === candidateId)
     if (!candidate) return
     const file = candidate.files.find(f => f.name === fileName)
+    // deleteFile が失敗（例外）した場合はメタデータの削除を中止する
     if (file) await window.electronAPI.deleteFile(file.path)
     await updateCandidate(candidateId, {
       files: candidate.files.filter(f => f.name !== fileName)
@@ -157,14 +162,13 @@ export function useCandidates() {
 // ルートディレクトリを再帰的にスキャンして候補者を読み込む
 async function scanCandidates(rootDir: string): Promise<Candidate[]> {
   const results: Candidate[] = []
-  const typeKeys = ['新卒', '中途']
 
-  for (const typeKey of typeKeys) {
-    const typeDir = `${rootDir}/${typeKey}`
+  for (const [type, folderName] of Object.entries(TYPE_FOLDER_MAP)) {
+    const typeDir = `${rootDir}/${folderName}`
     const exists = await window.electronAPI.exists(typeDir)
     if (!exists) continue
 
-    if (typeKey === '新卒') {
+    if (type === 'graduate') {
       const yearDirs = await window.electronAPI.listFiles(typeDir)
       for (const yearDir of yearDirs) {
         await scanStatusDirs(`${typeDir}/${yearDir}`, results)
@@ -182,9 +186,13 @@ async function scanStatusDirs(statusParentDir: string, results: Candidate[]) {
     const statusDirPath = `${statusParentDir}/${statusDir}`
     const candidateDirs = await window.electronAPI.listFiles(statusDirPath)
     for (const candidateDir of candidateDirs) {
-      const profilePath = `${statusDirPath}/${candidateDir}/profile.json`
-      const profile = await window.electronAPI.readJson<Candidate>(profilePath)
-      if (profile) results.push(profile)
+      try {
+        const profilePath = `${statusDirPath}/${candidateDir}/profile.json`
+        const profile = await window.electronAPI.readJson<Candidate>(profilePath)
+        if (profile) results.push(profile)
+      } catch {
+        // 個別の候補者読み込みエラーはスキップして他の候補者を継続ロード
+      }
     }
   }
 }

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -5,6 +5,8 @@ import { DEFAULT_SUB_STATUSES } from '@/types'
 interface SettingsContextValue {
   settings: AppSettings | null
   isLoading: boolean
+  isError: boolean
+  errorMessage: string | null
   saveSettings: (settings: AppSettings) => Promise<void>
 }
 
@@ -13,16 +15,25 @@ const SettingsContext = createContext<SettingsContextValue | null>(null)
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [settings, setSettings] = useState<AppSettings | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [isError, setIsError] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
     loadSettings()
   }, [])
 
   async function loadSettings() {
-    const settingsPath = await window.electronAPI.getSettingsPath()
-    const data = await window.electronAPI.readJson<AppSettings>(settingsPath)
-    setSettings(data ?? { rootDir: '', initialized: false, assignees: [], subStatuses: [...DEFAULT_SUB_STATUSES], webhookUrl: '', webhookType: null, messageTemplates: {} })
-    setIsLoading(false)
+    try {
+      const settingsPath = await window.electronAPI.getSettingsPath()
+      const data = await window.electronAPI.readJson<AppSettings>(settingsPath)
+      setSettings(data ?? { rootDir: '', initialized: false, assignees: [], subStatuses: [...DEFAULT_SUB_STATUSES], webhookUrl: '', webhookType: null, messageTemplates: {} })
+    } catch (e) {
+      setIsError(true)
+      setErrorMessage(e instanceof Error ? e.message : '設定の読み込みに失敗しました')
+      setSettings({ rootDir: '', initialized: false, assignees: [], subStatuses: [...DEFAULT_SUB_STATUSES], webhookUrl: '', webhookType: null, messageTemplates: {} })
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   async function saveSettings(newSettings: AppSettings) {
@@ -32,7 +43,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <SettingsContext.Provider value={{ settings, isLoading, saveSettings }}>
+    <SettingsContext.Provider value={{ settings, isLoading, isError, errorMessage, saveSettings }}>
       {children}
     </SettingsContext.Provider>
   )

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -2,6 +2,16 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from '
 import type { AppSettings } from '@/types'
 import { DEFAULT_SUB_STATUSES } from '@/types'
 
+const DEFAULT_SETTINGS: AppSettings = {
+  rootDir: '',
+  initialized: false,
+  assignees: [],
+  subStatuses: [...DEFAULT_SUB_STATUSES],
+  webhookUrl: '',
+  webhookType: null,
+  messageTemplates: {},
+}
+
 interface SettingsContextValue {
   settings: AppSettings | null
   isLoading: boolean
@@ -26,11 +36,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     try {
       const settingsPath = await window.electronAPI.getSettingsPath()
       const data = await window.electronAPI.readJson<AppSettings>(settingsPath)
-      setSettings(data ?? { rootDir: '', initialized: false, assignees: [], subStatuses: [...DEFAULT_SUB_STATUSES], webhookUrl: '', webhookType: null, messageTemplates: {} })
+      setSettings(data ?? { ...DEFAULT_SETTINGS, subStatuses: [...DEFAULT_SUB_STATUSES] })
     } catch (e) {
       setIsError(true)
       setErrorMessage(e instanceof Error ? e.message : '設定の読み込みに失敗しました')
-      setSettings({ rootDir: '', initialized: false, assignees: [], subStatuses: [...DEFAULT_SUB_STATUSES], webhookUrl: '', webhookType: null, messageTemplates: {} })
+      setSettings({ ...DEFAULT_SETTINGS, subStatuses: [...DEFAULT_SUB_STATUSES] })
     } finally {
       setIsLoading(false)
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,10 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootEl = document.getElementById('root')
+if (!rootEl) throw new Error('root element not found')
+
+ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,8 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, session } from 'electron'
-import { join, isAbsolute } from 'path'
+import { join, isAbsolute, dirname } from 'path'
 import { watch } from 'fs'
 import type { FSWatcher } from 'fs'
-import { access, mkdir, readdir, rename, copyFile, unlink, readFile, writeFile, rm } from 'fs/promises'
+import { access, mkdir, readdir, stat, rename, copyFile, unlink, readFile, writeFile, rm } from 'fs/promises'
 
 let mainWindow: BrowserWindow | null = null
 let fsWatcher: FSWatcher | null = null
@@ -38,6 +38,7 @@ function createWindow() {
       preload: join(__dirname, '../preload/index.js'),
       contextIsolation: true,
       nodeIntegration: false,
+      sandbox: false,
     },
     titleBarStyle: 'default',
     title: '採用管理',
@@ -98,6 +99,19 @@ async function pathExists(p: string): Promise<boolean> {
   }
 }
 
+// ---- IPC レスポンス型 ----
+
+/**
+ * IPC ハンドラーの統一レスポンス型。
+ * 新規追加ハンドラーはこの形式を使用すること。
+ * 既存ハンドラーは後方互換性のため変更しない。
+ */
+export type IpcResponse<T = void> = {
+  success: boolean
+  data?: T
+  error?: string
+}
+
 // ---- IPC ハンドラー ----
 
 // ディレクトリ選択ダイアログ
@@ -109,7 +123,8 @@ ipcMain.handle('dialog:selectDirectory', async () => {
 // ファイルをOSのデフォルトアプリで開く
 ipcMain.handle('shell:openFile', async (_event, filePath: string) => {
   validatePath(filePath, 'filePath')
-  await shell.openPath(filePath)
+  const errorMsg = await shell.openPath(filePath)
+  if (errorMsg) throw new Error(errorMsg)
 })
 
 // フォルダをエクスプローラーで開く
@@ -131,6 +146,8 @@ ipcMain.handle('fs:ensureDir', async (_event, dirPath: string) => {
 ipcMain.handle('fs:listFiles', async (_event, dirPath: string): Promise<string[]> => {
   validatePath(dirPath, 'dirPath')
   if (!(await pathExists(dirPath))) return []
+  const s = await stat(dirPath)
+  if (!s.isDirectory()) return []
   return readdir(dirPath)
 })
 
@@ -158,7 +175,7 @@ ipcMain.handle('fs:moveDir', async (_event, srcPath: string, destPath: string) =
   validatePath(srcPath, 'srcPath')
   validatePath(destPath, 'destPath')
   if (!(await pathExists(srcPath))) return false
-  const parentDir = destPath.substring(0, destPath.lastIndexOf('/')) || destPath.substring(0, destPath.lastIndexOf('\\'))
+  const parentDir = dirname(destPath)
   if (parentDir && !(await pathExists(parentDir))) {
     await mkdir(parentDir, { recursive: true })
   }
@@ -243,14 +260,7 @@ function validateWebhookUrl(url: string): void {
 // Webhook 送信（Teams / Slack）
 ipcMain.handle('webhook:post', async (_event, url: string, webhookType: 'teams' | 'slack', message: string) => {
   validateWebhookUrl(url)
-  let body: string
-  if (webhookType === 'teams') {
-    // Teams Incoming Webhook は {"text": "..."} で送信可能
-    body = JSON.stringify({ text: message })
-  } else {
-    // Slack Incoming Webhook
-    body = JSON.stringify({ text: message })
-  }
+  const body = JSON.stringify({ text: message })
 
   const TIMEOUT_MS = 10_000
   const MAX_RETRIES = 3

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,32 @@
-import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron'
-import { join } from 'path'
-import { existsSync, mkdirSync, readdirSync, renameSync, copyFileSync, unlinkSync, readFileSync, writeFileSync } from 'fs'
+import { app, BrowserWindow, ipcMain, dialog, shell, session } from 'electron'
+import { join, isAbsolute } from 'path'
+import { watch } from 'fs'
+import type { FSWatcher } from 'fs'
+import { access, mkdir, readdir, rename, copyFile, unlink, readFile, writeFile, rm } from 'fs/promises'
 
 let mainWindow: BrowserWindow | null = null
+let fsWatcher: FSWatcher | null = null
+
+/**
+ * 指定ディレクトリの監視を開始する。既存のウォッチャーがあれば先に閉じる。
+ */
+function startWatcher(dirPath: string): void {
+  if (fsWatcher) {
+    fsWatcher.close()
+    fsWatcher = null
+  }
+  try {
+    fsWatcher = watch(dirPath, { recursive: true }, () => {
+      mainWindow?.webContents.send('fs:changed')
+    })
+    fsWatcher.on('error', () => {
+      fsWatcher?.close()
+      fsWatcher = null
+    })
+  } catch {
+    fsWatcher = null
+  }
+}
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -27,6 +51,17 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [
+          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+        ],
+      },
+    })
+  })
+
   createWindow()
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
@@ -36,6 +71,32 @@ app.whenReady().then(() => {
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
 })
+
+// ---- バリデーション ----
+
+/**
+ * IPC ハンドラーが受け取るパス引数を検証する。
+ * 文字列かつ絶対パスでない場合はエラーをスローする。
+ */
+function validatePath(value: unknown, argName = 'path'): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`引数 "${argName}" は空でない文字列である必要があります`)
+  }
+  if (!isAbsolute(value)) {
+    throw new Error(`引数 "${argName}" は絶対パスである必要があります: "${value}"`)
+  }
+  return value
+}
+
+/** fs/promises の access を利用してパスの存在を確認する */
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p)
+    return true
+  } catch {
+    return false
+  }
+}
 
 // ---- IPC ハンドラー ----
 
@@ -47,65 +108,84 @@ ipcMain.handle('dialog:selectDirectory', async () => {
 
 // ファイルをOSのデフォルトアプリで開く
 ipcMain.handle('shell:openFile', async (_event, filePath: string) => {
+  validatePath(filePath, 'filePath')
   await shell.openPath(filePath)
 })
 
 // フォルダをエクスプローラーで開く
 ipcMain.handle('shell:openFolder', async (_event, folderPath: string) => {
+  validatePath(folderPath, 'folderPath')
   shell.showItemInFolder(folderPath)
 })
 
 // ディレクトリ作成
-ipcMain.handle('fs:ensureDir', (_event, dirPath: string) => {
-  if (!existsSync(dirPath)) {
-    mkdirSync(dirPath, { recursive: true })
+ipcMain.handle('fs:ensureDir', async (_event, dirPath: string) => {
+  validatePath(dirPath, 'dirPath')
+  if (!(await pathExists(dirPath))) {
+    await mkdir(dirPath, { recursive: true })
   }
   return true
 })
 
 // ファイル一覧取得
-ipcMain.handle('fs:listFiles', (_event, dirPath: string): string[] => {
-  if (!existsSync(dirPath)) return []
-  return readdirSync(dirPath)
+ipcMain.handle('fs:listFiles', async (_event, dirPath: string): Promise<string[]> => {
+  validatePath(dirPath, 'dirPath')
+  if (!(await pathExists(dirPath))) return []
+  return readdir(dirPath)
 })
 
 // ファイルコピー（drag&drop からフォルダへ）
-ipcMain.handle('fs:copyFile', (_event, srcPath: string, destPath: string) => {
-  copyFileSync(srcPath, destPath)
-  return true
+ipcMain.handle('fs:copyFile', async (_event, srcPath: string, destPath: string) => {
+  validatePath(srcPath, 'srcPath')
+  validatePath(destPath, 'destPath')
+  try {
+    await copyFile(srcPath, destPath)
+    return true
+  } catch {
+    return false
+  }
 })
 
 // ファイル削除
-ipcMain.handle('fs:deleteFile', (_event, filePath: string) => {
-  if (existsSync(filePath)) unlinkSync(filePath)
+ipcMain.handle('fs:deleteFile', async (_event, filePath: string) => {
+  validatePath(filePath, 'filePath')
+  if (await pathExists(filePath)) await unlink(filePath)
   return true
 })
 
 // フォルダ移動（ステータス変更時）
-ipcMain.handle('fs:moveDir', (_event, srcPath: string, destPath: string) => {
-  if (!existsSync(srcPath)) return false
+ipcMain.handle('fs:moveDir', async (_event, srcPath: string, destPath: string) => {
+  validatePath(srcPath, 'srcPath')
+  validatePath(destPath, 'destPath')
+  if (!(await pathExists(srcPath))) return false
   const parentDir = destPath.substring(0, destPath.lastIndexOf('/')) || destPath.substring(0, destPath.lastIndexOf('\\'))
-  if (parentDir && !existsSync(parentDir)) {
-    mkdirSync(parentDir, { recursive: true })
+  if (parentDir && !(await pathExists(parentDir))) {
+    await mkdir(parentDir, { recursive: true })
   }
-  renameSync(srcPath, destPath)
+  await rename(srcPath, destPath)
   return true
 })
 
 // JSONファイル読み込み
-ipcMain.handle('fs:readJson', (_event, filePath: string) => {
-  if (!existsSync(filePath)) return null
+ipcMain.handle('fs:readJson', async (_event, filePath: string) => {
+  validatePath(filePath, 'filePath')
+  if (!(await pathExists(filePath))) return null
   try {
-    return JSON.parse(readFileSync(filePath, 'utf-8'))
+    return JSON.parse(await readFile(filePath, 'utf-8'))
   } catch {
     return null
   }
 })
 
 // JSONファイル書き込み
-ipcMain.handle('fs:writeJson', (_event, filePath: string, data: unknown) => {
-  writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8')
-  return true
+ipcMain.handle('fs:writeJson', async (_event, filePath: string, data: unknown) => {
+  validatePath(filePath, 'filePath')
+  try {
+    await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8')
+    return true
+  } catch (err) {
+    throw err instanceof Error ? err : new Error(String(err))
+  }
 })
 
 // アプリ設定ファイルのパス（ユーザーデータディレクトリ）
@@ -113,13 +193,56 @@ ipcMain.handle('app:getSettingsPath', () => {
   return join(app.getPath('userData'), 'settings.json')
 })
 
-// ディレクトリ存在チェック
-ipcMain.handle('fs:exists', (_event, dirPath: string) => {
-  return existsSync(dirPath)
+// ディレクトリ削除（再帰的）
+ipcMain.handle('fs:deleteDir', async (_event, dirPath: string) => {
+  validatePath(dirPath, 'dirPath')
+  if (await pathExists(dirPath)) await rm(dirPath, { recursive: true, force: true })
+  return true
 })
+
+// ディレクトリ存在チェック
+ipcMain.handle('fs:exists', async (_event, dirPath: string) => {
+  validatePath(dirPath, 'dirPath')
+  return pathExists(dirPath)
+})
+
+// FSウォッチャー起動
+ipcMain.handle('fs:watch-start', async (_event, dirPath: string) => {
+  validatePath(dirPath, 'dirPath')
+  if (!(await pathExists(dirPath))) return false
+  startWatcher(dirPath)
+  return true
+})
+
+// 許可するWebhookのホスト一覧
+const ALLOWED_WEBHOOK_HOSTS = [
+  'teams.microsoft.com',
+  'hooks.slack.com',
+  'outlook.office.com',
+  'outlook.office365.com',
+]
+
+function validateWebhookUrl(url: string): void {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error('無効なURLです')
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error('HTTPSのURLのみ許可されています')
+  }
+  const isAllowed = ALLOWED_WEBHOOK_HOSTS.some(
+    host => parsed.hostname === host || parsed.hostname.endsWith('.' + host)
+  )
+  if (!isAllowed) {
+    throw new Error(`許可されていないホストです: ${parsed.hostname}`)
+  }
+}
 
 // Webhook 送信（Teams / Slack）
 ipcMain.handle('webhook:post', async (_event, url: string, webhookType: 'teams' | 'slack', message: string) => {
+  validateWebhookUrl(url)
   let body: string
   if (webhookType === 'teams') {
     // Teams Incoming Webhook は {"text": "..."} で送信可能
@@ -128,13 +251,34 @@ ipcMain.handle('webhook:post', async (_event, url: string, webhookType: 'teams' 
     // Slack Incoming Webhook
     body = JSON.stringify({ text: message })
   }
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body,
-  })
-  if (!response.ok) {
-    throw new Error(`Webhook 送信失敗: ${response.status} ${response.statusText}`)
+
+  const TIMEOUT_MS = 10_000
+  const MAX_RETRIES = 3
+  const RETRY_INTERVAL_MS = 1_000
+
+  let lastError: Error | null = null
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+        signal: controller.signal,
+      })
+      clearTimeout(timer)
+      if (!response.ok) {
+        throw new Error(`Webhook 送信失敗: ${response.status} ${response.statusText}`)
+      }
+      return true
+    } catch (err) {
+      clearTimeout(timer)
+      lastError = err instanceof Error ? err : new Error(String(err))
+      if (attempt < MAX_RETRIES) {
+        await new Promise(resolve => setTimeout(resolve, RETRY_INTERVAL_MS))
+      }
+    }
   }
-  return true
+  throw lastError ?? new Error('Webhook 送信失敗')
 })

--- a/src/pages/CandidateDetailPage.tsx
+++ b/src/pages/CandidateDetailPage.tsx
@@ -166,9 +166,13 @@ export function CandidateDetailPage() {
               <p className="text-sm text-gray-400">選考履歴はありません</p>
             ) : (
               <div className="space-y-3">
-                {[...candidate.stages].reverse().map((stage, i) => (
-                  <StageCard key={i} stage={stage} />
-                ))}
+                {[...candidate.stages].reverse().map((stage, i, reversed) => {
+                  // 逆順表示のため、次のインデックス（= 元配列での前のステージ）の日付を取得
+                  const prevStage = reversed[i + 1]
+                  return (
+                    <StageCard key={i} stage={stage} prevDate={prevStage?.date ?? null} />
+                  )
+                })}
               </div>
             )}
           </InfoCard>
@@ -191,7 +195,7 @@ export function CandidateDetailPage() {
             ) : (
               <ul className="space-y-1.5">
                 {candidate.files.map(f => (
-                  <li key={f.name} className="flex items-center gap-2 px-3 py-2 bg-gray-50 border border-gray-200 rounded-md">
+                  <li key={f.path} className="flex items-center gap-2 px-3 py-2 bg-gray-50 border border-gray-200 rounded-md">
                     <span className="text-xs px-1.5 py-0.5 bg-blue-100 text-blue-700 rounded shrink-0">
                       {f.category ?? 'その他'}
                     </span>
@@ -226,7 +230,7 @@ export function CandidateDetailPage() {
           onSubmit={async (newStatus, record) => {
             await changeStatus(candidate.id, newStatus, record)
             setShowStatusModal(false)
-            setNotifyState({ status: newStatus, deadline: (record as any).deadline ?? null })
+            setNotifyState({ status: newStatus, deadline: record.deadline ?? null })
           }}
         />
       )}
@@ -253,11 +257,22 @@ export function CandidateDetailPage() {
   )
 }
 
-function StageCard({ stage }: { stage: StageRecord }) {
+function StageCard({ stage, prevDate }: { stage: StageRecord; prevDate: string | null }) {
+  const daysDiff = prevDate
+    ? Math.round((new Date(stage.date).getTime() - new Date(prevDate).getTime()) / 86400000)
+    : null
+
   return (
     <div className="bg-gray-50 rounded-lg p-3 border border-gray-100">
       <div className="flex items-center justify-between mb-1">
-        <StatusBadge status={stage.stage} size="sm" />
+        <div className="flex items-center gap-2">
+          <StatusBadge status={stage.stage} size="sm" />
+          {daysDiff !== null && (
+            <span className={`text-xs ${daysDiff >= 14 ? 'text-amber-600 font-medium' : 'text-gray-400'}`}>
+              前ステップから{daysDiff}日
+            </span>
+          )}
+        </div>
         <div className="flex items-center gap-2 text-xs text-gray-500">
           {stage.rating && (
             <span className={`font-bold ${RATING_COLORS[stage.rating]}`}>{stage.rating}</span>
@@ -426,6 +441,7 @@ function InfoRow({ label, value, className }: { label: string; value: string; cl
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr)
+  if (isNaN(d.getTime())) return '—'
   return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`
 }
 

--- a/src/pages/CandidateDetailPage.tsx
+++ b/src/pages/CandidateDetailPage.tsx
@@ -22,6 +22,7 @@ export function CandidateDetailPage() {
 
   const [showStatusModal, setShowStatusModal] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const [notifyState, setNotifyState] = useState<{
     status: CandidateStatus; deadline: string | null
   } | null>(null)
@@ -38,16 +39,29 @@ export function CandidateDetailPage() {
     const files = Array.from(e.dataTransfer.files)
       .filter(f => /\.(pdf|xlsx|xls|docx|doc)$/i.test(f.name))
     for (const file of files) {
-      const path = window.electronAPI.getFilePath(file)
-      const category: FileCategory = detectFileCategory(file.name) ?? 'その他'
-      await addFile(candidate!.id, path, file.name, category)
+      try {
+        if (!window.electronAPI?.getFilePath) {
+          throw new Error('electronAPI が利用できません')
+        }
+        const path = window.electronAPI.getFilePath(file)
+        const category: FileCategory = detectFileCategory(file.name) ?? 'その他'
+        await addFile(candidate!.id, path, file.name, category)
+      } catch (err) {
+        console.error('ファイルの追加に失敗しました:', err)
+        alert(`ファイルの追加に失敗しました: ${file.name}`)
+      }
     }
   }
 
   async function handleDelete() {
     if (!confirm(`「${candidate!.name}」を削除しますか？`)) return
-    await deleteCandidate(candidate!.id)
-    navigate('/')
+    setDeleteError(null)
+    try {
+      await deleteCandidate(candidate!.id)
+      navigate('/')
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : '削除に失敗しました')
+    }
   }
 
   return (
@@ -95,6 +109,11 @@ export function CandidateDetailPage() {
           </button>
         </div>
       </div>
+      {deleteError && (
+        <div className="px-6 py-2 bg-red-50 border-b border-red-200">
+          <p className="text-sm text-red-600">{deleteError}</p>
+        </div>
+      )}
 
       <div className="p-6 grid grid-cols-3 gap-6">
         {/* 基本情報 */}
@@ -280,12 +299,15 @@ function StatusChangeModal({ candidate, statuses, registeredAssignees, subStatus
 
   async function handleSubmit() {
     setIsLoading(true)
-    await onSubmit(newStatus, {
-      date, evaluator, rating: rating || null, memo,
-      subStatus: subStatus || null,
-      deadline: deadline || null,
-    } as Omit<StageRecord, 'stage'>)
-    setIsLoading(false)
+    try {
+      await onSubmit(newStatus, {
+        date, evaluator, rating: rating || null, memo,
+        subStatus: subStatus || null,
+        deadline: deadline || null,
+      } as Omit<StageRecord, 'stage'>)
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (

--- a/src/pages/CandidateFormPage.tsx
+++ b/src/pages/CandidateFormPage.tsx
@@ -32,6 +32,9 @@ function today(): string {
   return new Date().toISOString().split('T')[0]
 }
 
+const GRADUATION_YEAR_MIN = new Date().getFullYear() - 1
+const GRADUATION_YEAR_MAX = new Date().getFullYear() + 10
+
 export function CandidateFormPage() {
   const navigate = useNavigate()
   const { addCandidate, addFile, candidates } = useCandidates()
@@ -198,7 +201,7 @@ export function CandidateFormPage() {
               </FieldGroup>
               {type === 'graduate' && (
                 <FieldGroup label="卒業予定年度" required>
-                  <Input type="number" value={graduationYear} onChange={e => setGraduationYear(e.target.value)} min={2024} max={2035} className="w-24" />
+                  <Input type="number" value={graduationYear} onChange={e => setGraduationYear(e.target.value)} min={GRADUATION_YEAR_MIN} max={GRADUATION_YEAR_MAX} className="w-24" />
                 </FieldGroup>
               )}
             </div>

--- a/src/pages/CandidateFormPage.tsx
+++ b/src/pages/CandidateFormPage.tsx
@@ -34,7 +34,7 @@ function today(): string {
 
 export function CandidateFormPage() {
   const navigate = useNavigate()
-  const { addCandidate, addFile } = useCandidates()
+  const { addCandidate, addFile, candidates } = useCandidates()
   const { settings, saveSettings } = useSettings()
   const registeredAssignees = settings?.assignees ?? []
 
@@ -54,7 +54,10 @@ export function CandidateFormPage() {
   const [droppedFiles, setDroppedFiles] = useState<DroppedFile[]>([])
   const [isDragging, setIsDragging] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
   const [createdCandidate, setCreatedCandidate] = useState<Candidate | null>(null)
+
+  const [showDuplicateWarning, setShowDuplicateWarning] = useState(false)
 
   const sources = type === 'graduate' ? GRADUATE_SOURCES : MID_CAREER_SOURCES
   const statuses = type === 'graduate' ? GRADUATE_STATUSES : MID_CAREER_STATUSES
@@ -113,6 +116,7 @@ export function CandidateFormPage() {
     e.preventDefault()
     if (!settings?.initialized || !allCategorized) return
     setIsSubmitting(true)
+    setSubmitError(null)
     const { school, department } = parseSchoolDept(schoolRaw)
     try {
       const candidate = await addCandidate({
@@ -127,6 +131,8 @@ export function CandidateFormPage() {
         await addFile(candidate.id, f.path, f.name, f.category!)
       }
       setCreatedCandidate(candidate)
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : '候補者の登録に失敗しました')
     } finally {
       setIsSubmitting(false)
     }
@@ -198,7 +204,15 @@ export function CandidateFormPage() {
             </div>
 
             <FieldGroup label="氏名" required>
-              <Input value={name} onChange={e => setName(e.target.value)} required />
+              <Input
+                value={name}
+                onChange={e => { setName(e.target.value); setShowDuplicateWarning(false) }}
+                onBlur={() => setShowDuplicateWarning(name.trim() !== '' && candidates.some(c => c.name === name.trim()))}
+                required
+              />
+              {showDuplicateWarning && (
+                <p className="text-xs text-orange-500 mt-1">同名の候補者がすでに登録されています。</p>
+              )}
             </FieldGroup>
 
             <FieldGroup label="学校・学部" hint="「大学名/学部名」または「大学名　学部名」（スペース2つ）で自動分割">
@@ -349,6 +363,12 @@ export function CandidateFormPage() {
             <p className="text-xs text-orange-500 mt-2">未判定のファイルの種別を選択してください</p>
           )}
         </div>
+
+        {submitError && (
+          <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md px-4 py-2">
+            {submitError}
+          </p>
+        )}
 
         <div className="flex gap-3">
           <button type="button" onClick={() => navigate(-1)} className="px-5 py-2 border border-gray-300 rounded-md text-sm font-medium hover:bg-gray-50">

--- a/src/pages/CandidateListPage.tsx
+++ b/src/pages/CandidateListPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useMemo } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useCandidates } from '@/contexts/CandidateContext'
 import { useSettings } from '@/contexts/SettingsContext'
 import { StatusBadge, SubStatusBadge, TypeBadge } from '@/components/common/Badge'
@@ -16,19 +16,53 @@ export function CandidateListPage() {
   const { candidates, isLoading } = useCandidates()
   const { settings } = useSettings()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
 
-  const [typeFilter, setTypeFilter] = useState<RecruitmentType | 'all'>('all')
-  const [statusFilter, setStatusFilter] = useState<CandidateStatus | 'all'>('all')
-  const [sourceFilter, setSourceFilter] = useState<RecruitmentSource | 'all'>('all')
-  const [yearFilter, setYearFilter] = useState<string>('all')
-  const [search, setSearch] = useState('')
-  const [sortKey, setSortKey] = useState<SortKey>('createdAt')
-  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const typeFilter = (searchParams.get('type') ?? 'all') as RecruitmentType | 'all'
+  const statusFilter = (searchParams.get('status') ?? 'all') as CandidateStatus | 'all'
+  const sourceFilter = (searchParams.get('source') ?? 'all') as RecruitmentSource | 'all'
+  const yearFilter = searchParams.get('year') ?? 'all'
+  const search = searchParams.get('q') ?? ''
+  const sortKey = (searchParams.get('sortKey') ?? 'createdAt') as SortKey
+  const sortDir = (searchParams.get('sortDir') ?? 'desc') as SortDir
 
-  const allStatuses = [...new Set([...GRADUATE_STATUSES, ...MID_CAREER_STATUSES])]
-  const allSources = [...GRADUATE_SOURCES, ...MID_CAREER_SOURCES]
-  const years = [...new Set(candidates.filter(c => c.graduationYear).map(c => c.graduationYear!))]
-    .sort((a, b) => Number(a) - Number(b))
+  function updateParam(key: string, value: string) {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      if (value === 'all' || value === '') {
+        next.delete(key)
+      } else {
+        next.set(key, value)
+      }
+      return next
+    }, { replace: true })
+  }
+
+  function setTypeFilter(v: RecruitmentType | 'all') { updateParam('type', v) }
+  function setStatusFilter(v: CandidateStatus | 'all') { updateParam('status', v) }
+  function setSourceFilter(v: RecruitmentSource | 'all') { updateParam('source', v) }
+  function setYearFilter(v: string) { updateParam('year', v) }
+  function setSearch(v: string) { updateParam('q', v) }
+
+  const hasActiveFilter = typeFilter !== 'all' || statusFilter !== 'all' || sourceFilter !== 'all' || yearFilter !== 'all' || search !== ''
+
+  function resetFilters() {
+    setSearchParams({}, { replace: true })
+  }
+
+  const allStatuses = useMemo(
+    () => [...new Set([...GRADUATE_STATUSES, ...MID_CAREER_STATUSES])],
+    []
+  )
+  const allSources = useMemo(
+    () => [...new Set([...GRADUATE_SOURCES, ...MID_CAREER_SOURCES])],
+    []
+  )
+  const years = useMemo(
+    () => [...new Set(candidates.filter(c => c.graduationYear).map(c => c.graduationYear!))]
+      .sort((a, b) => Number(a) - Number(b)),
+    [candidates]
+  )
 
   const filtered = useMemo(() => {
     let list = [...candidates]
@@ -79,12 +113,16 @@ export function CandidateListPage() {
   }
 
   function toggleSort(key: SortKey) {
-    if (sortKey === key) {
-      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
-    } else {
-      setSortKey(key)
-      setSortDir('asc')
-    }
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      if (sortKey === key) {
+        next.set('sortDir', sortDir === 'asc' ? 'desc' : 'asc')
+      } else {
+        next.set('sortKey', key)
+        next.set('sortDir', 'asc')
+      }
+      return next
+    }, { replace: true })
   }
 
   function deadlineClass(deadline: string | null) {
@@ -147,24 +185,32 @@ export function CandidateListPage() {
             placeholder="氏名・メール・担当者で検索"
             className="px-3 py-1.5 border border-gray-300 rounded-md text-sm w-52"
           />
-          <Select value={typeFilter} onChange={v => setTypeFilter(v as RecruitmentType | 'all')}>
+          <Select aria-label="採用区分フィルター" value={typeFilter} onChange={v => setTypeFilter(v as RecruitmentType | 'all')}>
             <option value="all">区分: 全て</option>
             <option value="graduate">新卒</option>
             <option value="mid-career">中途</option>
           </Select>
-          <Select value={statusFilter} onChange={v => setStatusFilter(v as CandidateStatus | 'all')}>
+          <Select aria-label="ステータスフィルター" value={statusFilter} onChange={v => setStatusFilter(v as CandidateStatus | 'all')}>
             <option value="all">ステータス: 全て</option>
             {allStatuses.map(s => <option key={s} value={s}>{s}</option>)}
           </Select>
-          <Select value={sourceFilter} onChange={v => setSourceFilter(v as RecruitmentSource | 'all')}>
+          <Select aria-label="採用媒体フィルター" value={sourceFilter} onChange={v => setSourceFilter(v as RecruitmentSource | 'all')}>
             <option value="all">媒体: 全て</option>
             {allSources.map(s => <option key={s} value={s}>{s}</option>)}
           </Select>
           {years.length > 0 && (
-            <Select value={yearFilter} onChange={v => setYearFilter(v)}>
+            <Select aria-label="卒業年度フィルター" value={yearFilter} onChange={v => setYearFilter(v)}>
               <option value="all">卒業年度: 全て</option>
               {years.map(y => <option key={y} value={y}>{y}年卒</option>)}
             </Select>
+          )}
+          {hasActiveFilter && (
+            <button
+              onClick={resetFilters}
+              className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 border border-gray-300 rounded-md transition-colors"
+            >
+              リセット
+            </button>
           )}
         </div>
       </div>
@@ -201,7 +247,11 @@ export function CandidateListPage() {
                 <tr
                   key={c.id}
                   onClick={() => navigate(`/candidates/${c.id}`)}
-                  className="hover:bg-blue-50 cursor-pointer transition-colors"
+                  onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') navigate(`/candidates/${c.id}`) }}
+                  tabIndex={0}
+                  role="row"
+                  aria-label={`${c.name} の詳細を開く`}
+                  className="hover:bg-blue-50 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
                 >
                   <td className="px-4 py-3 font-medium text-gray-900">{c.name}</td>
                   <td className="px-4 py-3">
@@ -231,15 +281,17 @@ export function CandidateListPage() {
   )
 }
 
-function Select({ value, onChange, children }: {
+function Select({ value, onChange, children, 'aria-label': ariaLabel }: {
   value: string
   onChange: (v: string) => void
   children: React.ReactNode
+  'aria-label'?: string
 }) {
   return (
     <select
       value={value}
       onChange={e => onChange(e.target.value)}
+      aria-label={ariaLabel}
       className="px-2 py-1.5 border border-gray-300 rounded-md text-sm bg-white"
     >
       {children}

--- a/src/pages/CandidateListPage.tsx
+++ b/src/pages/CandidateListPage.tsx
@@ -40,8 +40,8 @@ export function CandidateListPage() {
       const q = search.toLowerCase()
       list = list.filter(c =>
         c.name.toLowerCase().includes(q) ||
-        c.email.toLowerCase().includes(q) ||
-        c.assignee.toLowerCase().includes(q)
+        (c.email?.toLowerCase() ?? '').includes(q) ||
+        (c.assignee?.toLowerCase() ?? '').includes(q)
       )
     }
     list.sort((a, b) => {
@@ -52,6 +52,31 @@ export function CandidateListPage() {
     })
     return list
   }, [candidates, typeFilter, statusFilter, sourceFilter, yearFilter, search, sortKey, sortDir])
+
+  function exportCSV() {
+    const headers = ['氏名', '採用区分', 'ステータス', '採用媒体', '担当者', '応募日', '期限']
+    const typeLabel = (type: string) => type === 'graduate' ? '新卒' : type === 'mid-career' ? '中途' : type
+    const rows = filtered.map(c => [
+      c.name,
+      typeLabel(c.type),
+      c.status,
+      c.source ?? '',
+      c.assignee ?? '',
+      c.createdAt ? c.createdAt.slice(0, 10) : '',
+      c.deadline ? c.deadline.slice(0, 10) : '',
+    ])
+    const csvContent = [headers, ...rows]
+      .map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+      .join('\r\n')
+    const bom = '\uFEFF'
+    const blob = new Blob([bom + csvContent], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `candidates_${new Date().toISOString().slice(0, 10)}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) {
@@ -69,6 +94,14 @@ export function CandidateListPage() {
     if (days <= 3) return 'text-orange-500 font-semibold'
     return 'text-gray-600'
   }
+
+  const now = Date.now()
+  const expiredCount = filtered.filter(c => c.deadline && new Date(c.deadline).getTime() < now).length
+  const nearDeadlineCount = filtered.filter(c => {
+    if (!c.deadline) return false
+    const days = Math.ceil((new Date(c.deadline).getTime() - now) / 86400000)
+    return days >= 0 && days <= 3
+  }).length
 
   if (!settings?.initialized) {
     return (
@@ -89,12 +122,20 @@ export function CandidateListPage() {
           <h2 className="text-lg font-bold text-gray-800">
             候補者一覧 <span className="text-sm font-normal text-gray-500">({filtered.length}件)</span>
           </h2>
-          <button
-            onClick={() => navigate('/candidates/new')}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium transition-colors"
-          >
-            + 候補者追加
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={exportCSV}
+              className="px-4 py-2 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded-md text-sm font-medium transition-colors"
+            >
+              CSVエクスポート
+            </button>
+            <button
+              onClick={() => navigate('/candidates/new')}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium transition-colors"
+            >
+              + 候補者追加
+            </button>
+          </div>
         </div>
 
         {/* フィルター */}
@@ -128,8 +169,17 @@ export function CandidateListPage() {
         </div>
       </div>
 
+      {/* 期限警告バナー */}
+      {(expiredCount > 0 || nearDeadlineCount > 0) && (
+        <div className="mx-6 mt-3 px-4 py-2 bg-red-50 border border-red-200 rounded-md text-sm text-red-700 flex items-center gap-3">
+          <span className="font-medium">期限アラート:</span>
+          {expiredCount > 0 && <span>期限切れ: <strong>{expiredCount}件</strong></span>}
+          {nearDeadlineCount > 0 && <span>直近3日以内: <strong>{nearDeadlineCount}件</strong></span>}
+        </div>
+      )}
+
       {/* テーブル */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto mt-3">
         {isLoading ? (
           <div className="p-8 text-center text-gray-400">読み込み中...</div>
         ) : filtered.length === 0 ? (
@@ -218,5 +268,6 @@ function Th({ children, onClick, sortKey, currentSort, dir }: {
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr)
+  if (isNaN(d.getTime())) return '—'
   return `${d.getMonth() + 1}/${d.getDate()}`
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type Dispatch, type SetStateAction } from 'react'
 import { useSettings } from '@/contexts/SettingsContext'
 import type { AppSettings, CandidateStatus, RecruitmentType, WebhookType } from '@/types'
 import {
@@ -12,6 +12,8 @@ export function SettingsPage() {
   const { settings, saveSettings } = useSettings()
   const [tab, setTab] = useState<Tab>('general')
   const [saved, setSaved] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
 
   // general
   const [rootDir, setRootDir] = useState(settings?.rootDir ?? '')
@@ -64,11 +66,20 @@ export function SettingsPage() {
     }
   }
 
+  function addListItem(
+    value: string,
+    list: string[],
+    setList: Dispatch<SetStateAction<string[]>>,
+    setValue: Dispatch<SetStateAction<string>>,
+  ) {
+    const trimmed = value.trim()
+    if (!trimmed || list.includes(trimmed)) return
+    setList(prev => [...prev, trimmed])
+    setValue('')
+  }
+
   function addAssignee() {
-    const name = newAssignee.trim()
-    if (!name || assignees.includes(name)) return
-    setAssignees(prev => [...prev, name])
-    setNewAssignee('')
+    addListItem(newAssignee, assignees, setAssignees, setNewAssignee)
   }
 
   function removeAssignee(name: string) {
@@ -76,10 +87,7 @@ export function SettingsPage() {
   }
 
   function addSubStatus() {
-    const s = newSubStatus.trim()
-    if (!s || subStatuses.includes(s)) return
-    setSubStatuses(prev => [...prev, s])
-    setNewSubStatus('')
+    addListItem(newSubStatus, subStatuses, setSubStatuses, setNewSubStatus)
   }
 
   function removeSubStatus(s: string) {
@@ -100,6 +108,7 @@ export function SettingsPage() {
   }
 
   async function handleSave() {
+    if (isSaving) return
     const newSettings: AppSettings = {
       rootDir,
       initialized: !!rootDir,
@@ -109,9 +118,17 @@ export function SettingsPage() {
       webhookType: webhookType ?? detectWebhookType(webhookUrl),
       messageTemplates: templates,
     }
-    await saveSettings(newSettings)
-    setSaved(true)
-    setTimeout(() => setSaved(false), 2000)
+    setIsSaving(true)
+    try {
+      setSaveError(null)
+      await saveSettings(newSettings)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : '設定の保存に失敗しました')
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   const TABS: { key: Tab; label: string }[] = [
@@ -340,12 +357,15 @@ export function SettingsPage() {
           </div>
         )}
 
+        {saveError && (
+          <p className="text-xs text-red-500">{saveError}</p>
+        )}
         <button
           onClick={handleSave}
-          disabled={!rootDir}
+          disabled={!rootDir || isSaving}
           className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium transition-colors disabled:opacity-40"
         >
-          {saved ? '保存しました' : '保存'}
+          {isSaving ? '保存中...' : saved ? '保存しました' : '保存'}
         </button>
       </div>
     </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type Dispatch, type SetStateAction } from 'react'
+import { useState, useRef, useEffect, useMemo, type Dispatch, type SetStateAction } from 'react'
 import { useSettings } from '@/contexts/SettingsContext'
 import type { AppSettings, CandidateStatus, RecruitmentType, WebhookType } from '@/types'
 import {
@@ -14,6 +14,21 @@ export function SettingsPage() {
   const [saved, setSaved] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
+
+  // 初期値を記録し isDirty 判定に使用する
+  const initialValues = useRef({
+    rootDir: settings?.rootDir ?? '',
+    assignees: settings?.assignees ?? [],
+    subStatuses: settings?.subStatuses ?? [...DEFAULT_SUB_STATUSES],
+    webhookUrl: settings?.webhookUrl ?? '',
+    webhookType: settings?.webhookType ?? null,
+    templates: (() => {
+      const savedTemplates = settings?.messageTemplates ?? {}
+      const merged: Record<string, string> = { ...DEFAULT_TEMPLATES }
+      for (const [k, v] of Object.entries(savedTemplates)) merged[k] = v
+      return merged
+    })(),
+  })
 
   // general
   const [rootDir, setRootDir] = useState(settings?.rootDir ?? '')
@@ -43,6 +58,52 @@ export function SettingsPage() {
   })
   const [editingKey, setEditingKey] = useState<string | null>(null)
 
+  // settings が null から値にロードされたとき、各 state を同期する
+  useEffect(() => {
+    if (!settings) return
+    setRootDir(settings.rootDir ?? '')
+    setAssignees(settings.assignees ?? [])
+    setSubStatuses(settings.subStatuses ?? [...DEFAULT_SUB_STATUSES])
+    setWebhookUrl(settings.webhookUrl ?? '')
+    setWebhookType(settings.webhookType ?? null)
+    const merged: Record<string, string> = { ...DEFAULT_TEMPLATES }
+    for (const [k, v] of Object.entries(settings.messageTemplates ?? {})) merged[k] = v
+    setTemplates(merged)
+    initialValues.current = {
+      rootDir: settings.rootDir ?? '',
+      assignees: settings.assignees ?? [],
+      subStatuses: settings.subStatuses ?? [...DEFAULT_SUB_STATUSES],
+      webhookUrl: settings.webhookUrl ?? '',
+      webhookType: settings.webhookType ?? null,
+      templates: merged,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [!!settings])
+
+  // 未保存変更の検出
+  const isDirty = useMemo(() => {
+    const iv = initialValues.current
+    if (rootDir !== iv.rootDir) return true
+    if (webhookUrl !== iv.webhookUrl) return true
+    if (webhookType !== iv.webhookType) return true
+    if (assignees.length !== iv.assignees.length || assignees.some((a, i) => a !== iv.assignees[i])) return true
+    if (subStatuses.length !== iv.subStatuses.length || subStatuses.some((s, i) => s !== iv.subStatuses[i])) return true
+    const templateKeys = Object.keys({ ...iv.templates, ...templates })
+    if (templateKeys.some(k => templates[k] !== iv.templates[k])) return true
+    return false
+  }, [rootDir, webhookUrl, webhookType, assignees, subStatuses, templates])
+
+  // ページ離脱時の警告（ブラウザ標準のダイアログ）
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isDirty) {
+        e.preventDefault()
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [isDirty])
+
   function detectWebhookType(url: string): WebhookType | null {
     if (url.includes('webhook.office.com') || url.includes('teams.microsoft.com')) return 'teams'
     if (url.includes('hooks.slack.com')) return 'slack'
@@ -52,6 +113,11 @@ export function SettingsPage() {
   function handleWebhookUrlChange(url: string) {
     setWebhookUrl(url)
     setWebhookType(detectWebhookType(url))
+    setTestStatus('idle')
+  }
+
+  function handleWebhookTypeChange(type: WebhookType | null) {
+    setWebhookType(type)
     setTestStatus('idle')
   }
 
@@ -86,12 +152,32 @@ export function SettingsPage() {
     setAssignees(prev => prev.filter(a => a !== name))
   }
 
+  function moveAssignee(index: number, direction: 'up' | 'down') {
+    setAssignees(prev => {
+      const next = [...prev]
+      const target = direction === 'up' ? index - 1 : index + 1
+      if (target < 0 || target >= next.length) return prev
+      ;[next[index], next[target]] = [next[target], next[index]]
+      return next
+    })
+  }
+
   function addSubStatus() {
     addListItem(newSubStatus, subStatuses, setSubStatuses, setNewSubStatus)
   }
 
   function removeSubStatus(s: string) {
     setSubStatuses(prev => prev.filter(x => x !== s))
+  }
+
+  function moveSubStatus(index: number, direction: 'up' | 'down') {
+    setSubStatuses(prev => {
+      const next = [...prev]
+      const target = direction === 'up' ? index - 1 : index + 1
+      if (target < 0 || target >= next.length) return prev
+      ;[next[index], next[target]] = [next[target], next[index]]
+      return next
+    })
   }
 
   function updateTemplate(key: string, value: string) {
@@ -122,6 +208,8 @@ export function SettingsPage() {
     try {
       setSaveError(null)
       await saveSettings(newSettings)
+      // 保存成功時は初期値を更新して isDirty をリセットする
+      initialValues.current = { rootDir, assignees, subStatuses, webhookUrl, webhookType, templates }
       setSaved(true)
       setTimeout(() => setSaved(false), 2000)
     } catch (e) {
@@ -148,7 +236,7 @@ export function SettingsPage() {
         {TABS.map(t => (
           <button
             key={t.key}
-            onClick={() => setTab(t.key)}
+            onClick={() => { setTab(t.key); setEditingKey(null) }}
             className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
               tab === t.key
                 ? 'border-blue-600 text-blue-600'
@@ -209,10 +297,24 @@ export function SettingsPage() {
               ? <p className="text-xs text-gray-400">担当者が登録されていません</p>
               : (
                 <ul className="space-y-1">
-                  {assignees.map(a => (
+                  {assignees.map((a, i) => (
                     <li key={a} className="flex items-center justify-between px-3 py-1.5 bg-gray-50 border border-gray-100 rounded-md text-sm">
                       <span>{a}</span>
-                      <button onClick={() => removeAssignee(a)} className="text-gray-400 hover:text-red-500 text-xs">削除</button>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => moveAssignee(i, 'up')}
+                          disabled={i === 0}
+                          className="text-gray-400 hover:text-gray-600 text-xs px-1 disabled:opacity-30"
+                          title="上へ"
+                        >↑</button>
+                        <button
+                          onClick={() => moveAssignee(i, 'down')}
+                          disabled={i === assignees.length - 1}
+                          className="text-gray-400 hover:text-gray-600 text-xs px-1 disabled:opacity-30"
+                          title="下へ"
+                        >↓</button>
+                        <button onClick={() => removeAssignee(a)} className="text-gray-400 hover:text-red-500 text-xs ml-1">削除</button>
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -226,7 +328,7 @@ export function SettingsPage() {
           <div className="bg-white rounded-lg border border-gray-200 p-5">
             <h3 className="text-sm font-semibold text-gray-700 mb-1">サブステータスリスト</h3>
             <p className="text-xs text-gray-500 mb-3">
-              全ステータス共通で使えるサブステータスを管理します。順番はドラッグで変更できます。
+              全ステータス共通で使えるサブステータスを管理します。↑↓ボタンで順番を変更できます。
             </p>
             <div className="flex gap-2 mb-3">
               <input
@@ -246,10 +348,24 @@ export function SettingsPage() {
               ? <p className="text-xs text-gray-400">サブステータスが登録されていません</p>
               : (
                 <ul className="space-y-1">
-                  {subStatuses.map(s => (
+                  {subStatuses.map((s, i) => (
                     <li key={s} className="flex items-center justify-between px-3 py-1.5 bg-amber-50 border border-amber-100 rounded-md text-sm">
                       <span className="text-amber-800">{s}</span>
-                      <button onClick={() => removeSubStatus(s)} className="text-gray-400 hover:text-red-500 text-xs">削除</button>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => moveSubStatus(i, 'up')}
+                          disabled={i === 0}
+                          className="text-gray-400 hover:text-gray-600 text-xs px-1 disabled:opacity-30"
+                          title="上へ"
+                        >↑</button>
+                        <button
+                          onClick={() => moveSubStatus(i, 'down')}
+                          disabled={i === subStatuses.length - 1}
+                          className="text-gray-400 hover:text-gray-600 text-xs px-1 disabled:opacity-30"
+                          title="下へ"
+                        >↓</button>
+                        <button onClick={() => removeSubStatus(s)} className="text-gray-400 hover:text-red-500 text-xs ml-1">削除</button>
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -363,9 +479,13 @@ export function SettingsPage() {
         <button
           onClick={handleSave}
           disabled={!rootDir || isSaving}
-          className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium transition-colors disabled:opacity-40"
+          className={`w-full py-2 text-white rounded-md text-sm font-medium transition-colors disabled:opacity-40 ${
+            isDirty
+              ? 'bg-amber-500 hover:bg-amber-600'
+              : 'bg-blue-600 hover:bg-blue-700'
+          }`}
         >
-          {isSaving ? '保存中...' : saved ? '保存しました' : '保存'}
+          {isSaving ? '保存中...' : saved ? '保存しました' : isDirty ? '● 未保存の変更あり - 保存' : '保存'}
         </button>
       </div>
     </div>

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -8,10 +8,19 @@ export function SetupPage() {
   const [rootDir, setRootDir] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [dirError, setDirError] = useState<string | null>(null)
 
   async function handleSelectDir() {
     const dir = await window.electronAPI.selectDirectory()
-    if (dir) setRootDir(dir)
+    if (!dir) return
+    setDirError(null)
+    // フォルダへの書き込み可否を確認する
+    try {
+      await window.electronAPI.ensureDir(dir)
+      setRootDir(dir)
+    } catch {
+      setDirError('選択したフォルダへの書き込みができません。別のフォルダを選択してください。')
+    }
   }
 
   async function handleStart() {
@@ -31,6 +40,7 @@ export function SetupPage() {
       await saveSettings(settings)
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : '設定の保存に失敗しました')
+    } finally {
       setIsSaving(false)
     }
   }
@@ -43,6 +53,17 @@ export function SetupPage() {
           <p className="mt-2 text-sm text-gray-500">
             はじめに、候補者データと書類を保存するフォルダを指定してください。
           </p>
+        </div>
+
+        {/* 進捗インジケーター */}
+        <div className="flex items-center gap-2">
+          <div className="flex items-center justify-center w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold shrink-0">
+            1
+          </div>
+          <span className="text-sm font-medium text-blue-700">ステップ 1/1: フォルダ設定</span>
+          <div className="flex-1 h-1 bg-blue-200 rounded-full">
+            <div className="h-1 bg-blue-600 rounded-full" style={{ width: rootDir ? '100%' : '30%' }} />
+          </div>
         </div>
 
         <div className="space-y-2">
@@ -66,6 +87,9 @@ export function SetupPage() {
           </div>
           {rootDir && (
             <p className="text-xs text-gray-400 break-all">{rootDir}</p>
+          )}
+          {dirError && (
+            <p className="text-xs text-red-500">{dirError}</p>
           )}
         </div>
 

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -7,6 +7,7 @@ export function SetupPage() {
   const { saveSettings } = useSettings()
   const [rootDir, setRootDir] = useState('')
   const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   async function handleSelectDir() {
     const dir = await window.electronAPI.selectDirectory()
@@ -16,6 +17,7 @@ export function SetupPage() {
   async function handleStart() {
     if (!rootDir) return
     setIsSaving(true)
+    setSaveError(null)
     const settings: AppSettings = {
       rootDir,
       initialized: true,
@@ -25,8 +27,12 @@ export function SetupPage() {
       webhookType: null,
       messageTemplates: {},
     }
-    await saveSettings(settings)
-    setIsSaving(false)
+    try {
+      await saveSettings(settings)
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : '設定の保存に失敗しました')
+      setIsSaving(false)
+    }
   }
 
   return (
@@ -63,6 +69,9 @@ export function SetupPage() {
           )}
         </div>
 
+        {saveError && (
+          <p className="text-xs text-red-500">{saveError}</p>
+        )}
         <button
           onClick={handleStart}
           disabled={!rootDir || isSaving}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,6 +16,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   moveDir: (src: string, dest: string) => ipcRenderer.invoke('fs:moveDir', src, dest),
   readJson: <T>(filePath: string) => ipcRenderer.invoke('fs:readJson', filePath) as Promise<T | null>,
   writeJson: (filePath: string, data: unknown) => ipcRenderer.invoke('fs:writeJson', filePath, data),
+  deleteDir: (dirPath: string) => ipcRenderer.invoke('fs:deleteDir', dirPath),
   exists: (path: string) => ipcRenderer.invoke('fs:exists', path),
 
   // アプリ設定
@@ -27,4 +28,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // ファイルパス取得（Electron 28+ サンドボックス対応）
   getFilePath: (file: File) => webUtils.getPathForFile(file),
+
+  // FSウォッチャー
+  watchStart: (dirPath: string) => ipcRenderer.invoke('fs:watch-start', dirPath),
+  onFsChanged: (callback: () => void) => ipcRenderer.on('fs:changed', callback),
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
+import type { ElectronAPI } from '../types/electron'
 
-contextBridge.exposeInMainWorld('electronAPI', {
+const api = {
   // ダイアログ
   selectDirectory: () => ipcRenderer.invoke('dialog:selectDirectory'),
 
@@ -24,12 +25,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Webhook
   postWebhook: (url: string, type: 'teams' | 'slack', message: string) =>
-    ipcRenderer.invoke('webhook:post', url, type, message) as Promise<true>,
+    ipcRenderer.invoke('webhook:post', url, type, message) as Promise<boolean>,
 
   // ファイルパス取得（Electron 28+ サンドボックス対応）
-  getFilePath: (file: File) => webUtils.getPathForFile(file),
+  getFilePath: (file: File): string => {
+    if (!file || !(file instanceof File)) throw new Error('無効なファイルオブジェクトです')
+    return webUtils.getPathForFile(file)
+  },
 
   // FSウォッチャー
   watchStart: (dirPath: string) => ipcRenderer.invoke('fs:watch-start', dirPath),
   onFsChanged: (callback: () => void) => ipcRenderer.on('fs:changed', callback),
-})
+} satisfies ElectronAPI
+
+contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -12,7 +12,7 @@ export interface ElectronAPI {
   deleteDir: (dirPath: string) => Promise<boolean>
   exists: (path: string) => Promise<boolean>
   getSettingsPath: () => Promise<string>
-  postWebhook: (url: string, type: 'teams' | 'slack', message: string) => Promise<true>
+  postWebhook: (url: string, type: 'teams' | 'slack', message: string) => Promise<boolean>
   getFilePath: (file: File) => string
   watchStart: (dirPath: string) => Promise<boolean>
   onFsChanged: (callback: () => void) => void

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -9,10 +9,13 @@ export interface ElectronAPI {
   moveDir: (src: string, dest: string) => Promise<boolean>
   readJson: <T>(filePath: string) => Promise<T | null>
   writeJson: (filePath: string, data: unknown) => Promise<boolean>
+  deleteDir: (dirPath: string) => Promise<boolean>
   exists: (path: string) => Promise<boolean>
   getSettingsPath: () => Promise<string>
   postWebhook: (url: string, type: 'teams' | 'slack', message: string) => Promise<true>
   getFilePath: (file: File) => string
+  watchStart: (dirPath: string) => Promise<boolean>
+  onFsChanged: (callback: () => void) => void
 }
 
 declare global {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,7 +117,7 @@ export type TemplateVars = {
 
 export function renderTemplate(template: string, vars: TemplateVars): string {
   return template.replace(/\{\{(.+?)\}\}/g, (_, key) => {
-    return (vars as Record<string, string>)[key.trim()] ?? `{{${key}}}`
+    return (vars as Record<string, string>)[key.trim()] ?? ''
   })
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,8 @@ export type GraduateSource = 'マイナビ' | 'ツノル'
 export type MidCareerSource = 'Green' | 'Wantedly'
 export type RecruitmentSource = GraduateSource | MidCareerSource
 
-export type GraduateStatus =
+/** 新卒・中途に共通するステータス */
+export type CommonStatus =
   | '応募'
   | '書類選考'
   | '一次面接'
@@ -13,15 +14,9 @@ export type GraduateStatus =
   | '不採用'
   | '辞退'
 
-export type MidCareerStatus =
-  | '応募'
-  | 'カジュアル面談'
-  | '書類選考'
-  | '一次面接'
-  | '最終面接'
-  | '内定'
-  | '不採用'
-  | '辞退'
+export type GraduateStatus = CommonStatus
+
+export type MidCareerStatus = CommonStatus | 'カジュアル面談'
 
 export type CandidateStatus = GraduateStatus | MidCareerStatus
 
@@ -56,8 +51,13 @@ export const CATEGORY_KEYWORDS: Record<FileCategory, string[]> = {
   'その他': [],
 }
 
+const ALLOWED_FILE_EXTENSIONS = ['.pdf', '.docx', '.doc', '.xlsx', '.xls', '.png', '.jpg', '.jpeg']
+
 /** ファイル名からカテゴリを自動推定（判定できない場合は null）*/
 export function detectFileCategory(fileName: string): FileCategory | null {
+  const lower = fileName.toLowerCase()
+  const hasAllowedExt = ALLOWED_FILE_EXTENSIONS.some(ext => lower.endsWith(ext))
+  if (!hasAllowedExt) return null
   for (const [category, keywords] of Object.entries(CATEGORY_KEYWORDS) as [FileCategory, string[]][]) {
     if (category === 'その他') continue
     if (keywords.some(kw => fileName.includes(kw))) return category

--- a/src/utils/folderStructure.ts
+++ b/src/utils/folderStructure.ts
@@ -21,7 +21,14 @@ export function buildCandidateFolderPath(
 ): string {
   const typeDir = type === 'graduate' ? '新卒' : '中途'
   const statusDir = STATUS_FOLDER_MAP[status]
-  const candidateDir = `${sanitizeDirName(candidateName)}_${candidateId.substring(0, 8)}`
+  if (statusDir === undefined) {
+    throw new Error(`ステータスに対応するフォルダが定義されていません: "${status}"`)
+  }
+  const sanitizedName = sanitizeDirName(candidateName)
+  if (!sanitizedName) {
+    throw new Error(`候補者名が無効です: "${candidateName}"`)
+  }
+  const candidateDir = `${sanitizedName}_${candidateId.substring(0, 8)}`
 
   if (type === 'graduate' && graduationYear) {
     return join(rootDir, typeDir, `${graduationYear}年卒`, statusDir, candidateDir)
@@ -55,7 +62,12 @@ export async function moveCandidateFolder(
 
   const oldExists = await window.electronAPI.exists(candidate.folderPath)
   if (oldExists && candidate.folderPath !== newFolderPath) {
-    await window.electronAPI.moveDir(candidate.folderPath, newFolderPath)
+    const moved = await window.electronAPI.moveDir(candidate.folderPath, newFolderPath)
+    if (!moved) {
+      throw new Error(
+        `フォルダの移動に失敗しました: "${candidate.folderPath}" → "${newFolderPath}"`
+      )
+    }
   } else if (!oldExists) {
     await window.electronAPI.ensureDir(newFolderPath)
   }

--- a/src/utils/folderStructure.ts
+++ b/src/utils/folderStructure.ts
@@ -1,11 +1,22 @@
 import type { Candidate, RecruitmentType, CandidateStatus } from '@/types'
 import { STATUS_FOLDER_MAP } from '@/types'
 
+/** RecruitmentType とフォルダ名の対応表 */
+export const TYPE_FOLDER_MAP: Record<RecruitmentType, string> = {
+  graduate: '新卒',
+  'mid-career': '中途',
+}
+
+/**
+ * OS のパス区切り文字の差異を吸収しながらパスを結合する。
+ * Windows 絶対パス（ドライブレター付き）も正しく処理する。
+ */
 function join(...parts: string[]): string {
+  const sep = parts[0]?.includes('\\') ? '\\' : '/'
   return parts
     .map((p, i) => i === 0 ? p.replace(/[\\/]+$/, '') : p.replace(/^[\\/]+|[\\/]+$/g, ''))
     .filter(Boolean)
-    .join('/')
+    .join(sep)
 }
 
 /**
@@ -19,7 +30,7 @@ export function buildCandidateFolderPath(
   candidateId: string,
   graduationYear: string | null = null
 ): string {
-  const typeDir = type === 'graduate' ? '新卒' : '中途'
+  const typeDir = TYPE_FOLDER_MAP[type]
   const statusDir = STATUS_FOLDER_MAP[status]
   if (statusDir === undefined) {
     throw new Error(`ステータスに対応するフォルダが定義されていません: "${status}"`)
@@ -30,7 +41,7 @@ export function buildCandidateFolderPath(
   }
   const candidateDir = `${sanitizedName}_${candidateId.substring(0, 8)}`
 
-  if (type === 'graduate' && graduationYear) {
+  if (type === 'graduate' && graduationYear && /^\d{4}$/.test(graduationYear)) {
     return join(rootDir, typeDir, `${graduationYear}年卒`, statusDir, candidateDir)
   }
   return join(rootDir, typeDir, statusDir, candidateDir)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{jsx,tsx}'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## 修正 Issue 一覧

### セッション1（コミット 0f01e9a）
- Closes #2 Closes #3 Closes #4 Closes #5 Closes #6 Closes #7 Closes #8 Closes #9
- Closes #10 Closes #11 Closes #12 Closes #13 Closes #14 Closes #15 Closes #16 Closes #17 Closes #18 Closes #19
- Closes #20 Closes #21 Closes #22 Closes #23 Closes #24 Closes #25 Closes #26 Closes #27 Closes #28 Closes #29
- Closes #30 Closes #31 Closes #32 Closes #33 Closes #34 Closes #35 Closes #36
- Closes #37 Closes #38 Closes #39 Closes #40 Closes #41 Closes #42 Closes #43 Closes #44 Closes #45 Closes #46 Closes #47 Closes #48

### セッション2（コミット b7601cf）
- Closes #49 Closes #50 Closes #51 Closes #54 Closes #55 Closes #57 Closes #59 Closes #60
- Closes #62 Closes #66 Closes #67 Closes #68 Closes #69 Closes #70 Closes #73 Closes #75
- Closes #76 Closes #77 Closes #78 Closes #80 Closes #83 Closes #84 Closes #85 Closes #89
- Closes #91 Closes #92 Closes #93 Closes #94 Closes #96 Closes #97 Closes #100 Closes #103 Closes #104
- Closes #106 Closes #107 Closes #109 Closes #112 Closes #113 Closes #115

## 修正内容サマリー

### セキュリティ・堅牢性
- `sandbox: false` を BrowserWindow に明示（#49）
- `validatePath` による IPC 引数検証強化（#16）
- CSP ヘッダー追加（#29）
- Webhook URL ドメイン許可リスト検証（#7）
- ファイル拡張子ホワイトリストチェック（#109）
- フォルダ書き込み権限の事前検証（#104）
- `getFilePath` 引数バリデーション追加（#107）

### バグ修正
- `addFile` コピー失敗時にメタデータ追加を中止（#66）
- `removeFile` 削除失敗時にメタデータ削除を中止（#68）
- `changeStatus` の `settings!` 非 null アサーション除去（#69）
- `scanStatusDirs` 個別エラーをスキップして継続ロード（#67）
- `formatDate` Invalid Date ガード追加（#83）
- ファイルリストキーを `f.path` に変更（重複キー防止）（#84）
- `fs:moveDir` で `path.dirname()` 使用（Windows 対応）（#76）
- `fs:listFiles` で `isDirectory` チェック追加（#78）
- `shell:openFile` 失敗時に例外を伝播（#77）
- `buildCandidateFolderPath` で graduationYear を 4 桁数字に検証（#112）
- `postWebhook` 戻り値型を `Promise<boolean>` に修正（#106）
- SetupPage `isSaving` を `finally` でリセット（#103）
- SettingsPage の settings ロード後 state 同期（#97）

### UX・アクセシビリティ
- `ErrorBoundary` 追加（クラッシュ時にリロードボタン表示）（#55）
- `window.electronAPI` 未接続時のフォールバック画面（#57）
- SetupPage 完了時の CandidateProvider マウント競合防止（#54）
- フィルター一括リセットボタン（#93）
- テーブル行キーボードナビゲーション（#96）
- Select に `aria-label` 追加（#94）

### パフォーマンス・品質
- `allStatuses`/`allSources`/`years` を `useMemo` でメモ化（#91/#92）
- `electron.vite.config` を関数形式に変更・環境別 sourcemap 設定（#50/#51）
- `DEFAULT_SETTINGS` 定数をモジュールスコープに切り出し（#73）
- `TYPE_FOLDER_MAP` 定数を追加してマジック文字列を排除（#70）
- `tailwind.config` の content を `.tsx/.jsx` に絞り込み（#115）
- Webhook ラベルマップ定数化（#60）
- join 関数の Windows パス区切り対応（#113）

## テスト
- ビルド: 全修正後 `npm run build` で検証済み（EXIT:0）